### PR TITLE
config: refuse to serve from a config file others can edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ builds the GitHub release body from the matching `## <version>` section.
 ## 0.3.0 — 2026-09-10
 
 ### Added
+- **Config file permission check (Unix).** `rdc serve` and `rdc service install` refuse to run
+  when `config.toml` or its directory is owned by another user or writable by group/others,
+  because editing the allowlist is equivalent to desktop access. `rdc doctor` reports the check
+  as `config perms`; `RDC_INSECURE_CONFIG=1` downgrades the refusal to a warning.
 - **Windows support, verified on Windows 11.** `rdc service install` creates an elevated Task
   Scheduler logon task that runs the daemon in the interactive session with a log file;
   `service uninstall` stops the running daemon. Window `focus` implemented (foreground-thread

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2246,6 +2246,7 @@ dependencies = [
  "dirs",
  "enigo",
  "image",
+ "libc",
  "objc2-app-kit",
  "reqwest",
  "rmcp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 xcap = "0.9"
 arboard = { version = "3", default-features = false }
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [target.'cfg(target_os = "linux")'.dependencies]
 enigo = { version = "0.6", default-features = false, features = ["wayland", "x11rb"] }
 arboard = { version = "3", default-features = false, features = ["wayland-data-control"] }

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,6 +30,9 @@ TLS: the tailnet's WireGuard layer provides encryption and the identity.
   the rdc port at all.
 - `whois` is only as accurate as `tailscaled`. If the local daemon is unavailable, rdc falls back
   to the `tailscale` CLI; if neither works, every request is rejected.
+- The config file is the allowlist. On Unix the daemon refuses to start if `config.toml` or its
+  directory is owned by someone else or writable by group/others, since editing it is
+  equivalent to desktop access; `RDC_INSECURE_CONFIG=1` overrides with a warning.
 - `--dev-loopback` binds 127.0.0.1 and disables authentication for loopback connections. It is
   for local development and must never be used on a shared machine or forwarded.
 - MCP clients talk to `rdc mcp` over stdio on the operator's machine. The operator's agent

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -242,11 +242,30 @@ tailnet is already encrypted.
 3. A full URL, `http://host:port`.
 4. A bare `host` or `host:port`; the port defaults to `[serve].port`.
 
+## File permissions
+
+Whoever can edit `config.toml` can add themselves to `[serve].allow`, so the file is as
+sensitive as `~/.ssh/authorized_keys` and rdc treats it the same way. On Linux and macOS,
+`rdc serve` and `rdc service install` refuse to start when the config file or its directory is
+owned by another user or is writable by group or others; `rdc doctor` reports the same check as
+`config perms`. World-*readable* is fine (the allowlist is not a secret), but the recommended
+layout is:
+
+```sh
+chmod 700 ~/.config/rdc            # macOS: ~/Library/Application\ Support/rdc
+chmod 600 ~/.config/rdc/config.toml
+```
+
+Set `RDC_INSECURE_CONFIG=1` to turn the refusal into a logged warning if you have a deliberate
+reason (a shared dotfiles checkout, say). Windows is not checked: the per-user ACL on `%APPDATA%`
+already restricts it to the profile's owner and administrators.
+
 ## Environment variables
 
 | Variable | Effect |
 |---|---|
 | `RDC_TARGET` | default for `--target` |
 | `RDC_LOG` | log filter, e.g. `debug`, `rdc=debug,hyper=warn` (tracing syntax) |
+| `RDC_INSECURE_CONFIG` | set to `1` to run the daemon even if `config.toml` is writable by others (see [File permissions](#file-permissions)) |
 | `RDC_SIGN_IDENTITY` | macOS: code-signing identity name for `scripts/macos/bundle-and-sign.sh` (default `rdc-dev`) |
 | `RDC_ALLOW_ADHOC` | macOS: set to `1` to let the bundle script fall back to ad-hoc signing |

--- a/src/config.rs
+++ b/src/config.rs
@@ -240,6 +240,75 @@ pub fn path() -> PathBuf {
     dirs::config_dir().unwrap_or_else(|| PathBuf::from(".")).join("rdc").join("config.toml")
 }
 
+/// Environment variable that downgrades an insecure config file from an error to a warning.
+pub const INSECURE_CONFIG_ENV: &str = "RDC_INSECURE_CONFIG";
+
+/// Why the config file could be modified by someone other than its owner, if it could.
+///
+/// Editing `[serve].allow` is equivalent to full control of the desktop, so the file must be
+/// exactly as well protected as an `authorized_keys` file: owned by the user running the
+/// daemon, and neither it nor its directory writable by group or others. Only enforced on
+/// Unix; Windows ACLs on `%APPDATA%` already restrict the profile to its owner.
+pub fn insecure_reason(path: &std::path::Path) -> Option<String> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let me = unsafe { libc::getuid() };
+        let check = |p: &std::path::Path, what: &str| -> Option<String> {
+            let m = std::fs::metadata(p).ok()?;
+            if m.uid() != me {
+                return Some(format!("{what} {} is owned by uid {}, not by you (uid {me})", p.display(), m.uid()));
+            }
+            let mode = m.mode() & 0o777;
+            if mode & 0o022 != 0 {
+                let who = match (mode & 0o020 != 0, mode & 0o002 != 0) {
+                    (true, true) => "group- and world-writable",
+                    (true, false) => "group-writable",
+                    _ => "world-writable",
+                };
+                return Some(format!(
+                    "{what} {} is {who} (mode {mode:04o}); anyone who can edit it controls your desktop",
+                    p.display()
+                ));
+            }
+            None
+        };
+        if !path.exists() {
+            return None;
+        }
+        if let Some(r) = check(path, "config file") {
+            return Some(r);
+        }
+        if let Some(dir) = path.parent()
+            && let Some(r) = check(dir, "config directory")
+        {
+            return Some(r);
+        }
+        None
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        None
+    }
+}
+
+/// Refuse to run the daemon from a config file someone else could have edited, unless the
+/// operator has explicitly accepted that with `RDC_INSECURE_CONFIG=1`.
+pub fn enforce_permissions() -> Result<()> {
+    let p = path();
+    let Some(reason) = insecure_reason(&p) else { return Ok(()) };
+    if std::env::var(INSECURE_CONFIG_ENV).is_ok_and(|v| v == "1") {
+        tracing::warn!("{reason} ({INSECURE_CONFIG_ENV}=1 set, continuing)");
+        return Ok(());
+    }
+    anyhow::bail!(
+        "{reason}. Fix with `chmod 600 {}` and `chmod 700 {}`, or set {INSECURE_CONFIG_ENV}=1 to run anyway.",
+        p.display(),
+        p.parent().map(|d| d.display().to_string()).unwrap_or_default()
+    )
+}
+
 pub fn load() -> Result<Config> {
     let p = path();
     if !p.exists() {
@@ -353,6 +422,42 @@ allow = [{ who = "x", can = "shell" }]"#,
         assert_eq!(g.caps, caps(&[Capability::View, Capability::Clipboard]));
         assert!(parse_allow_flag("=view").is_err());
         assert!(parse_allow_flag("x=bogus").is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn permission_check_flags_writable_file_and_dir() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir().join(format!("rdc-permtest-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let file = dir.join("config.toml");
+        std::fs::write(&file, "[serve]\nallow = ['a']\n").unwrap();
+
+        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o600)).unwrap();
+        assert_eq!(insecure_reason(&file), None);
+        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o644)).unwrap();
+        assert_eq!(insecure_reason(&file), None, "world-readable is fine; the allowlist is not secret");
+
+        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o666)).unwrap();
+        let r = insecure_reason(&file).expect("world-writable file must be flagged");
+        assert!(r.contains("config file") && r.contains("world-writable"), "{r}");
+
+        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o620)).unwrap();
+        let r = insecure_reason(&file).unwrap();
+        assert!(r.contains("group-writable"), "{r}");
+
+        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o600)).unwrap();
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o777)).unwrap();
+        let r = insecure_reason(&file).expect("world-writable directory must be flagged");
+        assert!(r.contains("config directory"), "{r}");
+
+        // A missing file is not insecure; `load()` treats it as defaults.
+        assert_eq!(insecure_reason(&dir.join("nope.toml")), None);
+
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -171,6 +171,13 @@ pub async fn run(request_permissions: bool) -> anyhow::Result<bool> {
         Err(e) => line(None, "clipboard", format!("{e}")),
     }
     line(None, "config", crate::config::path().display().to_string());
+    match crate::config::insecure_reason(&crate::config::path()) {
+        None => line(Some(true), "config perms", "owned by you, not writable by others"),
+        Some(r) => {
+            healthy = false;
+            line(Some(false), "config perms", format!("{r}; `rdc serve` will refuse to start"));
+        }
+    }
     match crate::config::load() {
         Ok(cfg) => {
             match cfg.serve.grants() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,6 +209,7 @@ async fn run(cli: Cli) -> Result<()> {
 
     match cli.cmd {
         Cmd::Serve { bind, port, allow, dev_loopback } => {
+            config::enforce_permissions()?;
             let desktop: Arc<dyn Desktop> = Arc::new(LocalDesktop::new()?);
             let ts = tailscale::Tailscale::detect();
             let mut grants = cfg.serve.grants()?;
@@ -238,6 +239,9 @@ async fn run(cli: Cli) -> Result<()> {
             mcp::run(desktop, cli.target.clone(), max).await
         }
         Cmd::Service { op } => {
+            if matches!(op, ServiceOp::Install) {
+                config::enforce_permissions()?;
+            }
             if matches!(op, ServiceOp::Install) && cfg.serve.grants()?.is_empty() {
                 anyhow::bail!(
                     "[serve].allow in {} is empty; the service would start `rdc serve` with nobody allowed and exit. \


### PR DESCRIPTION
## Why
Whoever can edit `config.toml` can add themselves to `[serve].allow`, so the file is as sensitive as `~/.ssh/authorized_keys`, but nothing checked its ownership or mode.

## What
- On Unix, `rdc serve` and `rdc service install` refuse to start if the config file or its directory is owned by another user or writable by group/others. World-readable is allowed; the allowlist is not a secret.
- `rdc doctor` reports the check as `config perms`.
- `RDC_INSECURE_CONFIG=1` downgrades the refusal to a logged warning for deliberate cases (shared dotfiles checkouts).
- Windows is not checked; the per-user ACL on `%APPDATA%` already restricts it.
- Adds `libc` as a Unix-only dependency for `getuid`.

## Testing
- `cargo clippy --all-targets`, `cargo test` on Linux and Windows; the new Unix test exercises owner-only, world-readable, group-writable, world-writable file and world-writable directory cases.