### PR TITLE
windows: run the scheduled task at standard integrity by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ builds the GitHub release body from the matching `## <version>` section.
 ## Unreleased
 
 ### Changed
+- **Windows: the scheduled task no longer runs elevated by default.** `rdc service install`
+  now registers the logon task at `LeastPrivilege` run level, so the daemon holds only the
+  user's standard token and the install itself no longer needs an Administrator shell. Input
+  aimed at elevated windows is dropped by UIPI in this mode; pass `rdc service install
+  --elevated` (from an elevated PowerShell) to get the previous `HighestAvailable` behaviour.
+  Existing installs keep their run level until reinstalled.
+- Windows setup docs scope the firewall rule to the tailnet (`100.64.0.0/10`, Tailscale interface).
 - Docs: the configuration guide now shows the Tailscale access-policy rule (`grants` and `acls`
   forms) that must accompany rdc's grants, and the troubleshooting table distinguishes a
   policy timeout from an rdc 403.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -23,11 +23,12 @@ empty allowlist.
 | `--bind IP` | listen address (must be a Tailscale address) |
 | `--dev-loopback` | bind 127.0.0.1 and skip authentication for loopback. **Testing only.** |
 
-### `rdc service install | uninstall | status`
+### `rdc service install [--elevated] | uninstall | status`
 
 Manage a per-user background service that runs `rdc serve`: a LaunchAgent on macOS
-(`dev.rdc.daemon`), a `systemd --user` unit on Linux, an elevated Task Scheduler logon task on
-Windows. The service runs the binary at the path `rdc service install` was invoked from, so
+(`dev.rdc.daemon`), a `systemd --user` unit on Linux, a Task Scheduler logon task on Windows. On
+Windows the task runs at standard integrity; `--elevated` requests the highest run level so the
+daemon can drive elevated windows (see [Windows setup](setup-windows.md#how-it-has-to-run)). The service runs the binary at the path `rdc service install` was invoked from, so
 install from the final location (on macOS, from inside `rdc.app`).
 
 ### `rdc audit [-n N] [--json] [--path FILE]`

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -275,7 +275,7 @@ and the platform behaviour that determined how it is installed.
 | Linux, Wayland | portal Screenshot, then wlr-screencopy | wlr virtual pointer and keyboard | `hyprctl` on Hyprland | systemd user unit | GNOME and KDE lack the wlr input protocols: capture works there, input does not yet |
 | Linux, X11 | xcb | XTEST | window list only | systemd user unit | xcap reports geometry divided by DPI scale; input wants raw pixels, so rdc multiplies back |
 | macOS | `screencapture` (about 0.3 s); CoreGraphics fallback is slow on recent macOS | CGEvent via enigo | xcap list, NSRunningApplication | LaunchAgent inside a signed `rdc.app` | Screen Recording and Accessibility grants are keyed to the code signature; unsigned builds lose them on every rebuild |
-| Windows | GDI / Graphics Capture | `SendInput` normalised over the virtual desktop | xcap list, SetForegroundWindow | elevated Task Scheduler logon task | A service or SSH session is session 0 with no display, and non-elevated processes cannot send input to elevated windows |
+| Windows | GDI / Graphics Capture | `SendInput` normalised over the virtual desktop | xcap list, SetForegroundWindow | Task Scheduler logon task at standard integrity (`--elevated` opts into the highest run level) | A service or SSH session is session 0 with no display; a non-elevated daemon cannot send input to elevated windows, which is the documented trade-off |
 
 ## What gets recorded
 

--- a/docs/setup-windows.md
+++ b/docs/setup-windows.md
@@ -8,7 +8,7 @@ This guide is for the **machine being controlled**; the client side just needs t
 - Screenshots (about 0.3 s for 2560×1600), window list with titles, focus, mouse, keyboard,
   clipboard, Tailscale identity through the LocalAPI named pipe, the audit log.
 - `rdc service install` creates a Task Scheduler logon task that runs the daemon in your desktop
-  session, elevated, with a log file. Survives reboots and sign-in.
+  session as a standard user, with a log file. Survives reboots and sign-in.
 
 Not yet verified: multiple monitors (the code path exists, see issue #1), Windows 10.
 
@@ -20,11 +20,14 @@ Two Windows facts shape the setup:
    SSH session runs in session 0, which has no real display: `rdc doctor` there reports a fake
    1024×768 monitor and screenshots fail. `rdc service install` therefore uses a scheduled task
    that runs at logon as you, not a service.
-2. **It runs elevated.** Windows silently drops synthetic input aimed at elevated windows (an
-   Administrator PowerShell, an installer) and refuses to move focus to them from a
-   lower-integrity process. The task runs at the highest available run level so the whole
-   desktop stays controllable. UAC prompts on the secure desktop are still out of reach, by
-   design.
+2. **It runs as a standard user by default.** The task uses your normal, filtered token
+   (`LeastPrivilege` run level), so a remote-control process that anyone on your allowlist can drive holds no
+   more privilege than any app you double-click. The trade-off is UIPI: Windows silently drops
+   synthetic input aimed at *elevated* windows (an Administrator PowerShell, an installer) and
+   refuses to move focus to them from a lower-integrity process. If you need to drive elevated
+   windows remotely, `rdc service install --elevated` creates the task at the highest run level
+   instead; understand that this leaves a permanently elevated process listening on your
+   tailnet. UAC prompts on the secure desktop are out of reach either way, by design.
 
 ## Steps
 
@@ -52,19 +55,23 @@ Two Windows facts shape the setup:
    allow = ["you@example.com"]
    ```
 
-3. **Firewall.** Allow the port; the daemon only binds the Tailscale address regardless:
+3. **Firewall.** Allow the port from the tailnet only. The daemon binds just the Tailscale
+   address regardless, but scoping the rule means a future misconfiguration cannot expose it:
 
    ```powershell
-   New-NetFirewallRule -DisplayName "rdc (Tailscale)" -Direction Inbound -Protocol TCP -LocalPort 7770 -Action Allow
+   New-NetFirewallRule -DisplayName "rdc (Tailscale)" -Direction Inbound -Protocol TCP -LocalPort 7770 `
+     -RemoteAddress 100.64.0.0/10 -InterfaceAlias Tailscale -Action Allow
    ```
 
-4. **Install the task** from a PowerShell **run as Administrator**, signed in as the account
-   that uses the desktop. The task is registered at the highest run level, which needs an
-   elevated installer; `rdc service install` refuses otherwise.
+4. **Install the task** from a normal PowerShell, signed in as the account that uses the
+   desktop. The default task runs at standard integrity and needs no Administrator shell to
+   register. Only `--elevated` (highest run level) has to be run from an elevated PowerShell;
+   `rdc service install --elevated` refuses otherwise.
 
    ```powershell
-   rdc doctor            # tailscaled, config, grants; display info is only real from the desktop
-   rdc service install   # creates and starts task dev.rdc.daemon
+   rdc doctor                       # tailscaled, config, grants; display info is only real from the desktop
+   rdc service install              # creates and starts task dev.rdc.daemon as a standard user
+   rdc service install --elevated   # only if you must drive elevated windows (see above)
    rdc service status
    ```
 
@@ -88,6 +95,10 @@ install` with the new binary in place; it stops the previous instance first.
   consistent between screenshots and clicks, which is all that matters for the MCP mapping.
 - **Multi-monitor.** Pointer moves use `SendInput` normalised against the whole virtual desktop,
   so secondary displays should work, but this is untested until someone runs it with two screens.
+- **Elevated windows.** With the default (non-elevated) task, clicks and keystrokes aimed at an
+  elevated window are dropped and `focus` on it fails; the audit log records the action as
+  successful because Windows gives no error. Either close the elevated window, or reinstall with
+  `--elevated`.
 - **Focus.** Windows only lets a process take the foreground if it recently sent input. rdc
   attaches to the foreground thread's input queue (skipping threads that don't respond within
   200 ms) and, if that is refused, sends a zero-length mouse move and retries.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -42,7 +42,7 @@ which one failed.
 | Wayland: `no way to move the mouse` | compositor lacks the wlr virtual pointer protocol (GNOME, KDE) | not supported yet; capture works, input does not (issue #2) |
 | clicks land in the wrong place | coordinates from a stale or differently sized screenshot; or CLI given image pixels instead of desktop points | take a new screenshot; use `rdc mcp`, or convert as in [CLI reference](cli.md#mapping-a-screenshot-pixel-to-a-click) |
 | `key`: `"foo" is not a modifier` | typo in the chord | see the chord grammar in the CLI reference |
-| Windows: input ignored or focus refused for an elevated app | UIPI; the daemon runs at lower integrity | use `rdc service install` (task runs elevated) rather than starting `rdc serve` from a normal shell |
+| Windows: input ignored or focus refused for an elevated app | UIPI; the daemon runs at standard integrity by default | close the elevated window, or reinstall with `rdc service install --elevated` if you accept a permanently elevated daemon |
 | Windows: `doctor` shows a 1024×768 "WinDisc" display and screenshots fail | you're in an SSH or service session (session 0) | run the daemon via `rdc service install`; test from the client machine |
 
 ## MCP

--- a/skills/rdc/SKILL.md
+++ b/skills/rdc/SKILL.md
@@ -103,9 +103,11 @@ url = "http://host.tailnet.ts.net:7770"
 
 ### Windows
 
-Install the daemon with `rdc service install` (an elevated logon task in the user's desktop
-session); never run `rdc serve` from an SSH session, which has no real display. Coordinates are
-physical pixels. Details: `docs/setup-windows.md`.
+Install the daemon with `rdc service install` (a standard-user logon task in the user's desktop
+session); never run `rdc serve` from an SSH session, which has no real display. Input aimed at
+elevated windows (admin PowerShell, installers, UAC) is silently dropped unless the task was
+installed with `--elevated`; if a click on such a window has no effect, say so rather than
+retrying. Coordinates are physical pixels. Details: `docs/setup-windows.md`.
 
 ### Linux (Wayland/Hyprland)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,10 @@ enum Cmd {
     Service {
         #[arg(value_enum)]
         op: ServiceOp,
+        /// Windows: run the daemon elevated (highest run level) so it can click and type into
+        /// elevated windows. The default is a standard-integrity task. Ignored elsewhere.
+        #[arg(long)]
+        elevated: bool,
     },
     /// Show the most recent entries of this machine's audit log.
     Audit {
@@ -237,7 +241,7 @@ async fn run(cli: Cli) -> Result<()> {
             };
             mcp::run(desktop, cli.target.clone(), max).await
         }
-        Cmd::Service { op } => {
+        Cmd::Service { op, elevated } => {
             if matches!(op, ServiceOp::Install) && cfg.serve.grants()?.is_empty() {
                 anyhow::bail!(
                     "[serve].allow in {} is empty; the service would start `rdc serve` with nobody allowed and exit. \
@@ -245,8 +249,11 @@ async fn run(cli: Cli) -> Result<()> {
                     config::path().display()
                 );
             }
+            if elevated && (!cfg!(windows) || !matches!(op, ServiceOp::Install)) {
+                eprintln!("warning: --elevated only applies to `service install` on Windows; ignoring");
+            }
             service::run(match op {
-                ServiceOp::Install => service::Op::Install,
+                ServiceOp::Install => service::Op::Install { elevated },
                 ServiceOp::Uninstall => service::Op::Uninstall,
                 ServiceOp::Status => service::Op::Status,
             })

--- a/src/service/launchd.rs
+++ b/src/service/launchd.rs
@@ -16,7 +16,7 @@ pub fn run(op: Op) -> Result<()> {
     let plist = plist_path()?;
     let target = format!("gui/{}/{LABEL}", uid());
     match op {
-        Op::Install => {
+        Op::Install { .. } => {
             let bin = service_binary()?;
             if !bin.to_string_lossy().contains(".app/Contents/MacOS/") {
                 eprintln!(

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -17,7 +17,11 @@ pub const LABEL: &str = "dev.rdc.daemon";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Op {
-    Install,
+    Install {
+        /// Windows only: run the daemon with the user's full (elevated) token so it can drive
+        /// elevated windows. Off by default; ignored on other platforms.
+        elevated: bool,
+    },
     Uninstall,
     Status,
 }

--- a/src/service/systemd.rs
+++ b/src/service/systemd.rs
@@ -14,7 +14,7 @@ pub fn run(op: Op) -> Result<()> {
     let unit = unit_path()?;
     let name = format!("{LABEL}.service");
     match op {
-        Op::Install => {
+        Op::Install { .. } => {
             let bin = service_binary()?;
             std::fs::create_dir_all(unit.parent().unwrap())?;
             let text = format!(

--- a/src/service/windows.rs
+++ b/src/service/windows.rs
@@ -46,7 +46,7 @@ fn stderr_of(out: &std::process::Output) -> String {
 }
 
 /// True when this process runs with a high-integrity (elevated) token. Registering a task at
-/// the highest run level requires it.
+/// the highest run level requires it; a least-privilege task does not.
 fn is_elevated() -> bool {
     Command::new("whoami")
         .args(["/groups"])
@@ -86,8 +86,19 @@ fn xml_escape(s: &str) -> String {
     s.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;").replace('"', "&quot;")
 }
 
-fn task_xml(bin: &Path, log: &Path) -> String {
+/// Run level for the task principal. `LeastPrivilege` (the default) is the user's standard,
+/// filtered token: the daemon holds no more privilege than any app the user double-clicks,
+/// which is all a screen-and-input surface needs. The cost is UIPI: Windows drops synthetic
+/// input aimed at *elevated* windows and refuses to focus them from a lower-integrity process.
+/// `HighestAvailable` (`--elevated`) buys that back at the price of a permanently elevated
+/// remote-control process. UAC prompts on the secure desktop are out of reach either way.
+fn run_level(elevated: bool) -> &'static str {
+    if elevated { "HighestAvailable" } else { "LeastPrivilege" }
+}
+
+fn task_xml(bin: &Path, log: &Path, elevated: bool) -> String {
     let who = xml_escape(&principal());
+    let level = run_level(elevated);
     let args = xml_escape(&format!("--headless \"{}\" --log-file \"{}\" serve", bin.display(), log.display()));
     format!(
         r#"<?xml version="1.0" encoding="UTF-16"?>
@@ -105,7 +116,7 @@ fn task_xml(bin: &Path, log: &Path) -> String {
     <Principal id="Author">
       <UserId>{who}</UserId>
       <LogonType>InteractiveToken</LogonType>
-      <RunLevel>HighestAvailable</RunLevel>
+      <RunLevel>{level}</RunLevel>
     </Principal>
   </Principals>
   <Settings>
@@ -159,11 +170,11 @@ fn remove_legacy_task() {
 pub fn run(op: Op) -> Result<()> {
     let name = task_name();
     match op {
-        Op::Install => {
-            if !is_elevated() {
+        Op::Install { elevated } => {
+            if elevated && !is_elevated() {
                 bail!(
-                    "installing the rdc task needs an elevated PowerShell (run as Administrator) under the account that will use the desktop; \
-                     the task runs at the highest run level so it can drive elevated windows"
+                    "--elevated registers the task at the highest run level, which needs an elevated PowerShell (run as Administrator) \
+                     under the account that will use the desktop. Without --elevated the task runs at standard integrity and installs from a normal shell."
                 );
             }
             let bin = service_binary()?;
@@ -172,7 +183,7 @@ pub fn run(op: Op) -> Result<()> {
             let log = logs.join("serve.log");
             remove_legacy_task();
             let xml_path = std::env::temp_dir().join(format!("{name}.xml"));
-            write_utf16(&xml_path, &task_xml(&bin, &log))?;
+            write_utf16(&xml_path, &task_xml(&bin, &log, elevated))?;
             let out = schtasks(&["/Create", "/F", "/TN", &name, "/XML", &xml_path.to_string_lossy()])?;
             let _ = std::fs::remove_file(&xml_path);
             if !out.status.success() {
@@ -186,6 +197,17 @@ pub fn run(op: Op) -> Result<()> {
                 bail!("task created but /Run failed: {}", stderr_of(&out));
             }
             println!("installed scheduled task {name} → {}\nlogs: {}", bin.display(), log.display());
+            if elevated {
+                println!(
+                    "run level: HighestAvailable (elevated). The daemon holds your full admin token; \
+                     reinstall without --elevated to drop it."
+                );
+            } else {
+                println!(
+                    "run level: LeastPrivilege (standard user). Input to elevated windows will be ignored by \
+                     Windows; if you need that, reinstall with `rdc service install --elevated` from an admin shell."
+                );
+            }
             Ok(())
         }
         Op::Uninstall => {
@@ -227,5 +249,21 @@ pub fn run(op: Op) -> Result<()> {
             }
             Ok(())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_level_defaults_to_least_privilege() {
+        assert_eq!(run_level(false), "LeastPrivilege");
+        assert_eq!(run_level(true), "HighestAvailable");
+        let x = task_xml(Path::new(r"C:\rdc\rdc.exe"), Path::new(r"C:\logs\serve.log"), false);
+        assert!(x.contains("<RunLevel>LeastPrivilege</RunLevel>"));
+        assert!(!x.contains("HighestAvailable"));
+        let x = task_xml(Path::new(r"C:\rdc\rdc.exe"), Path::new(r"C:\logs\serve.log"), true);
+        assert!(x.contains("<RunLevel>HighestAvailable</RunLevel>"));
     }
 }


### PR DESCRIPTION
## Why
The logon task was registered with `RunLevel=HighestAvailable`, so a remote-control process that anyone on the allowlist can drive held the user's full admin token at all times. The only thing that bought was UIPI bypass (input to elevated windows), which most deployments never need.

## What
- The task is now registered at `LeastPrivilege`; the daemon runs with the standard filtered token, and installing no longer requires an Administrator shell.
- `rdc service install --elevated` restores `HighestAvailable` for people who must drive elevated windows. The existing "must be run elevated to install" check now applies only to that path.
- `Op::Install` carries the flag so the other platforms ignore it (with a warning if misused).
- `service install` prints which run level it used and how to switch.
- Docs: `setup-windows.md` explains the trade-off, the install step no longer demands an admin PowerShell, the firewall rule is scoped to `100.64.0.0/10` on the Tailscale interface, and `cli.md`, `troubleshooting.md`, `how-it-works.md` and the agent skill no longer claim the task is elevated.

## Testing
- `cargo clippy --all-targets`, `cargo test` on Windows 11 (new unit test checks the generated task XML for both run levels), plus manual `rdc service --help` and the `--elevated` misuse warning.
- Existing installs keep their run level until reinstalled; noted in the changelog.