### PR TITLE
Audit streaming and rdc audit-view live viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ builds the GitHub release body from the matching `## <version>` section.
 
 ## Unreleased
 
+### Added
+- **Audit streaming.** `[serve.audit] stream = "http://…/v1/ingest"` (or `rdc serve
+  --audit-stream URL`) POSTs every audit entry, batched as `application/x-ndjson`, to an HTTP
+  endpoint, with retry and backoff; the local file stays the record. `stream_token` adds a
+  bearer token for third-party collectors.
+- **`rdc audit-view`**, a live audit viewer: receives streams from any number of daemons (and
+  follows local files with `--follow`), stores them, and serves a page that updates as entries
+  arrive, with text, outcome and host filters. Same gate as the daemon: Tailscale bind, Host
+  check, `whois` identity, allowlist. Configured under `[audit_view]`.
+- Audit entries carry `host` (the daemon's node name); the viewer adds `via` (the sending
+  node) and never trusts the sender for it. Old lines without `host` still parse.
+
 ### Changed
 - Release flow: pull requests target a `release/<version>` branch, which is tested on real
   machines before a reviewed merge into `main`. `main` is protected. CONTRIBUTING and AGENTS

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2245,6 +2245,7 @@ dependencies = [
  "clap",
  "dirs",
  "enigo",
+ "futures",
  "http-body-util",
  "image",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ async-trait = "0.1"
 axum = { version = "0.8", features = ["json", "query", "macros"] }
 base64 = "0.22"
 bytes = "1"
+futures = { version = "0.3", default-features = false, features = ["std"] }
 clap = { version = "4", features = ["derive", "env"] }
 dirs = "6"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ button, and carries on.
   address and asks the local `tailscaled` who each caller is. You allow tailnet logins, device
   names or tags. Your tailnet is the security boundary.
 - **Scoped access and an audit trail.** Each allowed identity can be limited to `view`, `input`
-  or `clipboard`, and every request or rejection is written to a JSON-lines audit log.
+  or `clipboard`, and every request or rejection is written to a JSON-lines audit log. Daemons
+  can stream it to `rdc audit-view`, a live page for all your machines, or to any collector
+  that takes newline-delimited JSON over HTTP.
 - **No shell.** rdc is a screen-and-input surface only. Use SSH for commands.
 - **One binary**, written in Rust. The same executable is the daemon, the CLI and the MCP server.
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -22,6 +22,7 @@
 
 - [MCP tools](mcp.md)
 - [CLI reference](cli.md)
+- [Audit log and live viewer](audit.md)
 - [Troubleshooting](troubleshooting.md)
 
 # Project

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -1,0 +1,124 @@
+# Audit log and live viewer
+
+Every request an `rdc serve` daemon handles, and every one it refuses, becomes one JSON line in
+its audit file. This page covers reading that file, streaming it off the machine, and watching
+several machines at once in a browser.
+
+## The file
+
+Default location: `rdc/audit.jsonl` in the platform state directory (`~/.local/state/rdc/` on
+Linux, `~/Library/Application Support/rdc/` on macOS, `%LOCALAPPDATA%\rdc\` on Windows). It is
+created with owner-only permissions and rotated at `max_size_mb`, keeping `keep` old files.
+
+```bash
+rdc audit              # last 50 entries as a table
+rdc audit -n 200 --json
+```
+
+One entry:
+
+```json
+{"ts":"2026-09-11T18:02:12.430Z","host":"studio-mac","peer":"100.64.0.11",
+ "login":"brian@example.com","node":"laptop","method":"POST","path":"/v1/act",
+ "action":"input.click 640,400 Left x1","outcome":"ok","status":200,"ms":8}
+```
+
+| Field | Meaning |
+|---|---|
+| `ts` | UTC time, RFC 3339 |
+| `host` | the machine whose desktop this is about (the daemon's node name) |
+| `peer` | source IP of the request |
+| `login`, `node`, `tags` | the caller's Tailscale identity, when one was established. Tagged devices have no `login`. |
+| `method`, `path` | the HTTP request |
+| `action` | what was asked for. Typed text is recorded as a character count, never as content. |
+| `outcome` | `ok`, `denied` (bad host, unknown peer, not allowed, missing capability) or `error` |
+| `status` | HTTP status returned |
+| `detail` | why it was denied or failed |
+| `ms` | how long the request took |
+| `via` | added by the viewer: the node that sent this entry over the network |
+
+Strings from the network (window titles, key chords, host names) have control characters
+replaced before they are written, so a hostile value cannot break the line framing or drive the
+terminal of whoever reads the log.
+
+## Streaming entries off the machine
+
+A daemon can also POST its entries, as they happen, to an HTTP endpoint:
+
+```toml
+[serve.audit]
+stream = "http://laptop.example-tailnet.ts.net:7771/v1/ingest"
+# stream_token = "..."   # sent as `Authorization: Bearer`, for third-party collectors
+```
+
+or `rdc serve --audit-stream http://...`.
+
+Entries are batched (a few hundred lines or half a second, whichever comes first) into one
+request with `Content-Type: application/x-ndjson`: one JSON object per line, newline
+terminated. A failed request is retried with backoff up to 30 seconds while new entries queue
+behind it. If the endpoint stays down and the queue fills, new entries are dropped for the stream
+and a warning is logged. The local file is never affected. Treat the stream as a live feed and
+the file as the record.
+
+Any collector that accepts newline-delimited JSON over HTTP works: an `rdc audit-view` instance,
+Vector's `http_server` source, a small script, or a log service's ingest URL with
+`stream_token`. Keep the endpoint on your tailnet or behind TLS; the stream carries who did what
+on your machines.
+
+## The live viewer
+
+`rdc audit-view` is a small web server that receives streams from your daemons and shows them in
+one page, newest first, updating as entries arrive.
+
+```bash
+rdc audit-view --allow brian@example.com
+# audit viewer at http://100.64.0.11:7771/  (daemons stream to http://100.64.0.11:7771/v1/ingest)
+```
+
+Then point each daemon at it with `[serve.audit] stream = ".../v1/ingest"` and open the URL in a
+browser on an allowed machine.
+
+The viewer applies the same rules as the daemon. It listens only on a Tailscale address (or
+loopback with `--dev-loopback`), refuses requests whose `Host` header is not one of its own
+names, and identifies every caller, daemon or browser, through `tailscaled whois`. Both the
+daemons that send and the people who view must be in its allowlist. Capabilities in the
+allowlist are ignored here; membership is what counts. Entries the viewer itself refuses show up
+in the page too, with the viewer's own host name.
+
+The viewer sets `via` on every entry it receives to the sending node's name and never trusts
+the sender for it. An entry that arrives without a `host` is attributed to its sender.
+
+Options:
+
+| Flag | Config | Meaning |
+|---|---|---|
+| `--port` | `[audit_view].port` | default `7771` |
+| `--bind` | `[audit_view].bind` | default: this node's Tailscale IPv4 |
+| `--allow` | `[audit_view].allow` | who may send and view; same shapes as `[serve].allow` |
+| `--store PATH` | `[audit_view].store` | where received entries are kept; default `audit-view.jsonl` in the state dir, rotated like the daemon's file |
+| `--no-store` | | keep entries in memory only |
+| `--follow PATH` | `[audit_view].follow` | also follow a local audit file, for the daemon on the same machine |
+| `--dev-loopback` | | bind 127.0.0.1 without authentication, for testing |
+
+The page has a text filter, an outcome filter, a per-host filter, and a pause box that holds new
+rows until you uncheck it. It is plain HTML and JavaScript served with a strict content security
+policy; log content is only ever inserted as text.
+
+### Endpoints
+
+| Route | Used by | Purpose |
+|---|---|---|
+| `POST /v1/ingest` | daemons | body is `application/x-ndjson`, up to 8 MiB; returns `{accepted, rejected}` and `400` if any line was not an entry |
+| `GET /v1/recent?n=500&host=` | the page | the most recent entries held in memory (up to 5000) |
+| `GET /v1/events` | the page | server-sent events, one `entry` event per line |
+| `GET /` | you | the page |
+
+### Tailscale policy
+
+Daemons connect to the viewer's port, so the policy must allow the daemon machines to reach
+`<viewer>:7771`, and your own devices too for the page. With the tagging pattern from
+[Grants and Tailscale policy](grants-and-acls.md):
+
+```jsonc
+{"action": "accept", "src": ["tag:rdc-host", "autogroup:member"], "dst": ["tag:rdc-viewer:7771"]}
+```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -37,6 +37,12 @@ Show the last N entries (default 50) of this machine's audit log as a table, or 
 lines with `--json`. The file is `[serve.audit].path` or the platform default. See
 [Configuration](configuration.md#audit-log).
 
+### `rdc audit-view [--port N] [--bind IP] [--allow WHO]... [--store FILE | --no-store] [--follow FILE]...`
+
+Run the live audit viewer: receive JSON-lines audit streams from `rdc serve` instances over
+Tailscale and show them in a browser. Same binding and identity rules as `serve`. Details in
+[Audit log and live viewer](audit.md).
+
 ### `rdc doctor [--request-permissions]`
 
 Prints what rdc can see on this machine: platform and session type, `tailscaled` connectivity and

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,6 +44,15 @@ enabled = true                 # default
 # path = "/var/log/rdc/audit.jsonl"   # default: rdc/audit.jsonl in the platform state dir
 max_size_mb = 50               # rotate above this size
 keep = 5                       # keep audit.jsonl.1 … .5
+# stream = "http://laptop.example-tailnet.ts.net:7771/v1/ingest"  # also POST entries here
+# stream_token = "..."         # Authorization: Bearer for third-party collectors
+
+# The live viewer, `rdc audit-view`. See "Audit log and live viewer".
+[audit_view]
+port = 7771                    # default
+allow = ["alice@example.com", "tag:rdc-host"]   # who may send entries and open the page
+# store = "/var/log/rdc/audit-view.jsonl"       # default: audit-view.jsonl in the state dir
+# follow = ["/home/alice/.local/state/rdc/audit.jsonl"]  # also show this machine's own log
 
 # Names you can pass to `--target` on the client side.
 [targets.studio-mac]

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,9 @@ pub struct Config {
     pub serve: ServeConfig,
     #[serde(default)]
     pub targets: BTreeMap<String, Target>,
+    /// Settings for `rdc audit-view`, the live audit viewer.
+    #[serde(default)]
+    pub audit_view: AuditViewConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -154,19 +157,22 @@ impl Grant {
     }
 }
 
+fn resolve_allow(entries: &[AllowEntry], where_: &str) -> Result<Vec<ResolvedGrant>> {
+    let mut out = Vec::new();
+    for e in entries {
+        match e {
+            AllowEntry::Simple(s) if !s.trim().is_empty() => out.push(ResolvedGrant::full(vec![s.trim().to_string()])),
+            AllowEntry::Simple(_) => {}
+            AllowEntry::Grant(g) => out.push(g.resolve().with_context(|| format!("in {where_}"))?),
+        }
+    }
+    Ok(out)
+}
+
 impl ServeConfig {
     /// Every grant from `allow` and `[[serve.grant]]`, validated.
     pub fn grants(&self) -> Result<Vec<ResolvedGrant>> {
-        let mut out = Vec::new();
-        for e in &self.allow {
-            match e {
-                AllowEntry::Simple(s) if !s.trim().is_empty() => {
-                    out.push(ResolvedGrant::full(vec![s.trim().to_string()]))
-                }
-                AllowEntry::Simple(_) => {}
-                AllowEntry::Grant(g) => out.push(g.resolve().context("in [serve].allow")?),
-            }
-        }
+        let mut out = resolve_allow(&self.allow, "[serve].allow")?;
         for g in &self.grant {
             out.push(g.resolve().context("in [[serve.grant]]")?);
         }
@@ -201,11 +207,93 @@ pub struct AuditConfig {
     /// How many rotated files to keep (`audit.jsonl.1` … `.N`).
     #[serde(default = "default_audit_keep")]
     pub keep: u32,
+    /// Also POST every entry, as JSON lines, to this HTTP URL: an `rdc audit-view` instance or
+    /// any collector that accepts `application/x-ndjson`.
+    #[serde(default)]
+    pub stream: Option<String>,
+    /// Sent as `Authorization: Bearer …` with the stream. Not needed for `rdc audit-view`,
+    /// which identifies the sender through Tailscale.
+    #[serde(default)]
+    pub stream_token: Option<String>,
 }
 
 impl Default for AuditConfig {
     fn default() -> Self {
-        Self { enabled: true, path: None, max_size_mb: default_audit_mb(), keep: default_audit_keep() }
+        Self {
+            enabled: true,
+            path: None,
+            max_size_mb: default_audit_mb(),
+            keep: default_audit_keep(),
+            stream: None,
+            stream_token: None,
+        }
+    }
+}
+
+pub const DEFAULT_VIEW_PORT: u16 = 7771;
+
+/// `[audit_view]`: the live viewer that daemons stream their audit entries to.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuditViewConfig {
+    #[serde(default = "default_view_port")]
+    pub port: u16,
+    /// Address to bind. Default: this node's Tailscale IPv4.
+    #[serde(default)]
+    pub bind: Option<String>,
+    /// Who may send entries and who may open the page. Same shapes as `[serve].allow`;
+    /// capabilities are ignored here, membership is what counts.
+    #[serde(default)]
+    pub allow: Vec<AllowEntry>,
+    /// Extra accepted `Host` names, as for `[serve]`.
+    #[serde(default)]
+    pub hosts: Vec<String>,
+    /// Keep received entries in this file. Default: `rdc/audit-view.jsonl` in the state dir.
+    /// Set `store = false` on the command line with `--no-store`.
+    #[serde(default)]
+    pub store: Option<PathBuf>,
+    /// Local audit files to follow as well (for the machine the viewer runs on).
+    #[serde(default)]
+    pub follow: Vec<PathBuf>,
+    #[serde(default = "default_audit_mb")]
+    pub max_size_mb: u64,
+    #[serde(default = "default_audit_keep")]
+    pub keep: u32,
+}
+
+impl Default for AuditViewConfig {
+    fn default() -> Self {
+        Self {
+            port: DEFAULT_VIEW_PORT,
+            bind: None,
+            allow: vec![],
+            hosts: vec![],
+            store: None,
+            follow: vec![],
+            max_size_mb: default_audit_mb(),
+            keep: default_audit_keep(),
+        }
+    }
+}
+
+fn default_view_port() -> u16 {
+    DEFAULT_VIEW_PORT
+}
+
+impl AuditViewConfig {
+    pub fn grants(&self) -> Result<Vec<ResolvedGrant>> {
+        resolve_allow(&self.allow, "[audit_view].allow")
+    }
+
+    pub fn store_config(&self) -> AuditConfig {
+        AuditConfig {
+            enabled: true,
+            path: Some(self.store.clone().unwrap_or_else(|| state_dir().join("audit-view.jsonl"))),
+            max_size_mb: self.max_size_mb,
+            keep: self.keep,
+            stream: None,
+            stream_token: None,
+        }
     }
 }
 
@@ -318,6 +406,7 @@ pub fn load() -> Result<Config> {
     let cfg: Config = toml::from_str(&raw).with_context(|| format!("parsing {}", p.display()))?;
     // Fail early on malformed grants so the daemon never starts with a half-read allowlist.
     cfg.serve.grants().with_context(|| format!("in {}", p.display()))?;
+    cfg.audit_view.grants().with_context(|| format!("in {}", p.display()))?;
     Ok(cfg)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod server;
 mod service;
 mod tailscale;
 mod view;
+mod viewer;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
@@ -48,6 +49,34 @@ enum Cmd {
         /// `tag:ops=view`, `studio-laptop=view,clipboard`. Repeatable; adds to config.
         #[arg(long = "allow")]
         allow: Vec<String>,
+        /// Also stream audit entries (JSON lines) to this URL, e.g. an `rdc audit-view`
+        /// instance: `http://laptop.example.ts.net:7771/v1/ingest`. Overrides config.
+        #[arg(long)]
+        audit_stream: Option<String>,
+        /// Bind 127.0.0.1 and skip authentication for loopback. Testing only.
+        #[arg(long)]
+        dev_loopback: bool,
+    },
+    /// Collect audit entries streamed from `rdc serve` instances and show them live in a browser.
+    AuditView {
+        /// Address to bind (default: this node's Tailscale IPv4).
+        #[arg(long)]
+        bind: Option<IpAddr>,
+        /// TCP port (default 7771 or `[audit_view].port`).
+        #[arg(long)]
+        port: Option<u16>,
+        /// Identity allowed to send entries and to open the page. Repeatable; adds to config.
+        #[arg(long = "allow")]
+        allow: Vec<String>,
+        /// Keep received entries in this file (default: audit-view.jsonl in the state dir).
+        #[arg(long)]
+        store: Option<PathBuf>,
+        /// Keep entries in memory only.
+        #[arg(long, conflicts_with = "store")]
+        no_store: bool,
+        /// Also follow a local audit file, e.g. this machine's own daemon log. Repeatable.
+        #[arg(long)]
+        follow: Vec<PathBuf>,
         /// Bind 127.0.0.1 and skip authentication for loopback. Testing only.
         #[arg(long)]
         dev_loopback: bool,
@@ -212,7 +241,7 @@ async fn run(cli: Cli) -> Result<()> {
     let cfg = config::load()?;
 
     match cli.cmd {
-        Cmd::Serve { bind, port, allow, dev_loopback } => {
+        Cmd::Serve { bind, port, allow, audit_stream, dev_loopback } => {
             config::enforce_permissions()?;
             let desktop: Arc<dyn Desktop> = Arc::new(LocalDesktop::new()?);
             let ts = tailscale::Tailscale::detect();
@@ -221,6 +250,10 @@ async fn run(cli: Cli) -> Result<()> {
                 grants.push(config::parse_allow_flag(a)?);
             }
             let bind = bind.or_else(|| cfg.serve.bind.as_deref().and_then(|s| s.parse().ok()));
+            let mut audit = cfg.serve.audit.clone();
+            if audit_stream.is_some() {
+                audit.stream = audit_stream;
+            }
             server::serve(
                 desktop,
                 ts,
@@ -228,9 +261,43 @@ async fn run(cli: Cli) -> Result<()> {
                     bind,
                     port: port.unwrap_or(cfg.serve.port),
                     grants,
-                    audit: cfg.serve.audit.clone(),
+                    audit,
                     hosts: cfg.serve.hosts.clone(),
                     dev_loopback,
+                },
+            )
+            .await
+        }
+        Cmd::AuditView { bind, port, allow, store, no_store, follow, dev_loopback } => {
+            config::enforce_permissions()?;
+            let ts = tailscale::Tailscale::detect();
+            let v = &cfg.audit_view;
+            let mut grants = v.grants()?;
+            for a in &allow {
+                grants.push(config::parse_allow_flag(a)?);
+            }
+            let bind = bind.or_else(|| v.bind.as_deref().and_then(|s| s.parse().ok()));
+            let store = if no_store {
+                None
+            } else {
+                let mut c = v.store_config();
+                if let Some(p) = store {
+                    c.path = Some(p);
+                }
+                Some(c)
+            };
+            let mut follow = follow;
+            follow.extend(v.follow.iter().cloned());
+            viewer::run(
+                ts,
+                viewer::ViewOpts {
+                    bind,
+                    port: port.unwrap_or(v.port),
+                    grants,
+                    hosts: v.hosts.clone(),
+                    dev_loopback,
+                    store,
+                    follow,
                 },
             )
             .await
@@ -355,7 +422,12 @@ async fn client(cfg: &config::Config, target: &str, cmd: Cmd) -> Result<()> {
             Some(r) => print_json(&r.whoami().await?),
             None => anyhow::bail!("whoami needs a remote --target"),
         },
-        Cmd::Serve { .. } | Cmd::Mcp { .. } | Cmd::Doctor { .. } | Cmd::Service { .. } | Cmd::Audit { .. } => {
+        Cmd::Serve { .. }
+        | Cmd::AuditView { .. }
+        | Cmd::Mcp { .. }
+        | Cmd::Doctor { .. }
+        | Cmd::Service { .. }
+        | Cmd::Audit { .. } => {
             unreachable!()
         }
     }

--- a/src/server/audit.rs
+++ b/src/server/audit.rs
@@ -13,6 +13,12 @@ use std::time::SystemTime;
 pub struct Entry {
     /// RFC 3339 UTC timestamp.
     pub ts: String,
+    /// The machine whose desktop this entry is about (the daemon's node name).
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub host: String,
+    /// Set by `rdc audit-view` on entries it received over the network: the node that sent them.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub via: Option<String>,
     pub peer: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub login: Option<String>,
@@ -44,6 +50,8 @@ impl Entry {
     pub fn new(peer: &str, id: Option<&Identity>, method: &str, path: &str) -> Self {
         Self {
             ts: now_rfc3339(),
+            host: String::new(),
+            via: None,
             peer: peer.to_string(),
             login: id.and_then(|i| i.login.clone()),
             node: id.map(|i| i.node.clone()),
@@ -81,6 +89,21 @@ impl Entry {
         self.ms = Some(started.elapsed().as_millis() as u64);
         self
     }
+
+    /// Re-sanitize every string field. Used for entries that arrived over the network, whose
+    /// sender may not be an honest `rdc serve`.
+    pub fn sanitized(mut self) -> Self {
+        for f in [&mut self.ts, &mut self.host, &mut self.peer, &mut self.method, &mut self.path, &mut self.outcome] {
+            *f = sanitize(f);
+        }
+        for v in
+            [&mut self.via, &mut self.login, &mut self.node, &mut self.action, &mut self.detail].into_iter().flatten()
+        {
+            *v = sanitize(v);
+        }
+        self.tags = self.tags.iter().take(32).map(|t| sanitize(t)).collect();
+        self
+    }
 }
 
 struct Sink {
@@ -94,16 +117,21 @@ struct Sink {
 pub struct Audit {
     sink: Option<Mutex<Sink>>,
     path: Option<PathBuf>,
+    /// Stamped into entries that do not name a host yet.
+    host: String,
+    stream: Option<super::stream::Streamer>,
 }
 
 impl Audit {
     pub fn disabled() -> Self {
-        Self { sink: None, path: None }
+        Self { sink: None, path: None, host: String::new(), stream: None }
     }
 
-    pub fn open(cfg: &AuditConfig) -> anyhow::Result<Self> {
+    /// Open the audit file named by `cfg`. `host` is this machine's node name; it is written into
+    /// every entry so a viewer collecting several machines can tell them apart.
+    pub fn open(cfg: &AuditConfig, host: &str) -> anyhow::Result<Self> {
         if !cfg.enabled {
-            return Ok(Self::disabled());
+            return Ok(Self { host: host.to_string(), ..Self::disabled() });
         }
         let path = cfg.resolved_path();
         if let Some(dir) = path.parent() {
@@ -120,23 +148,46 @@ impl Audit {
                 written,
             })),
             path: Some(path),
+            host: host.to_string(),
+            stream: None,
         })
+    }
+
+    /// Also send every entry, as JSON lines, to an HTTP endpoint. Best effort: the file stays
+    /// the record; the stream is batched, retried, and dropped when the endpoint stays down.
+    pub fn stream_to(&mut self, url: &str, token: Option<&str>) -> anyhow::Result<()> {
+        self.stream = Some(super::stream::Streamer::spawn(url, token)?);
+        Ok(())
+    }
+
+    /// Flush what the streamer still holds. Call once before exiting.
+    pub async fn shutdown(&self) {
+        if let Some(s) = &self.stream {
+            s.shutdown().await;
+        }
     }
 
     pub fn path(&self) -> Option<&Path> {
         self.path.as_deref()
     }
 
-    pub fn record(&self, e: Entry) {
-        let Some(sink) = &self.sink else { return };
-        let Ok(mut s) = sink.lock() else { return };
-        let mut line = match serde_json::to_string(&e) {
+    pub fn record(&self, mut e: Entry) {
+        if e.host.is_empty() {
+            e.host = self.host.clone();
+        }
+        let line = match serde_json::to_string(&e) {
             Ok(l) => l,
             Err(err) => {
                 tracing::warn!("audit: serialize failed: {err}");
                 return;
             }
         };
+        if let Some(stream) = &self.stream {
+            stream.push(line.clone());
+        }
+        let Some(sink) = &self.sink else { return };
+        let Ok(mut s) = sink.lock() else { return };
+        let mut line = line;
         line.push('\n');
         if s.written + line.len() as u64 > s.max_bytes
             && let Err(err) = s.rotate()
@@ -232,8 +283,9 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("rdc-audit-test-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         let path = dir.join("audit.jsonl");
-        let cfg = AuditConfig { enabled: true, path: Some(path.clone()), max_size_mb: 1, keep: 2 };
-        let a = Audit::open(&cfg).unwrap();
+        let cfg =
+            AuditConfig { enabled: true, path: Some(path.clone()), max_size_mb: 1, keep: 2, ..Default::default() };
+        let a = Audit::open(&cfg, "studio-mac").unwrap();
         // Force a tiny cap so rotation triggers.
         a.sink.as_ref().unwrap().lock().unwrap().max_bytes = 400;
         for i in 0..6 {
@@ -251,7 +303,27 @@ mod tests {
         let last = tail(&path, 10).unwrap();
         assert!(!last.is_empty());
         assert!(last.last().unwrap().action.as_deref().unwrap().starts_with("input.key"));
+        assert_eq!(last[0].host, "studio-mac");
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn old_lines_without_host_still_parse() {
+        let line = r#"{"ts":"2026-09-01T00:00:00.000Z","peer":"100.64.0.2","method":"GET","path":"/v1/state","outcome":"ok","status":200}"#;
+        let e: Entry = serde_json::from_str(line).unwrap();
+        assert!(e.host.is_empty() && e.via.is_none());
+    }
+
+    #[test]
+    fn sanitized_cleans_every_field() {
+        let mut e = Entry::new("100.64.0.1", None, "GET", "/v1/state");
+        e.host = "mac\u{1b}[2J".into();
+        e.via = Some("x\ny".into());
+        e.tags = vec!["tag:\u{7}a".into()];
+        let e = e.sanitized();
+        assert_eq!(e.host, "mac\u{fffd}[2J");
+        assert_eq!(e.via.as_deref(), Some("x\u{fffd}y"));
+        assert_eq!(e.tags, vec!["tag:\u{fffd}a".to_string()]);
     }
 
     #[test]

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -1,6 +1,6 @@
 //! Identify the peer behind each connection with tailscaled whois and check the allowlist.
 
-use super::{AppState, is_tailscale_ip};
+use super::is_tailscale_ip;
 use crate::config::ResolvedGrant;
 use crate::proto::{ApiError, Capability, Identity, RdcError};
 use crate::tailscale::Tailscale;
@@ -117,6 +117,13 @@ impl Identify for Tailscale {
     }
 }
 
+/// What the auth middleware needs from an application state: the policy, and somewhere to
+/// write the entries for requests it refuses.
+pub trait Gate: Clone + Send + Sync + 'static {
+    fn auth(&self) -> &Auth;
+    fn record(&self, e: super::audit::Entry);
+}
+
 pub struct Auth {
     ts: Arc<dyn Identify>,
     allow: Allowlist,
@@ -202,8 +209,8 @@ pub fn error_response(e: &RdcError) -> Response {
     (status, axum::Json(body)).into_response()
 }
 
-pub async fn middleware(
-    State(state): State<AppState>,
+pub async fn middleware<S: Gate>(
+    State(state): State<S>,
     ConnectInfo(peer): ConnectInfo<SocketAddr>,
     mut req: Request<Body>,
     next: Next,
@@ -216,16 +223,16 @@ pub async fn middleware(
         .or_else(|| req.uri().authority().map(|a| a.to_string()));
     let (method, path) = (req.method().to_string(), req.uri().path().to_string());
     let peer_ip = peer.ip().to_string();
-    if let Err(e) = state.auth.check_host(host.as_deref()) {
+    if let Err(e) = state.auth().check_host(host.as_deref()) {
         tracing::warn!(peer = %peer_ip, error = %e, "rejected");
-        state.audit.record(super::audit::Entry::new(&peer_ip, None, &method, &path).denied(421, e.message()));
+        state.record(super::audit::Entry::new(&peer_ip, None, &method, &path).denied(421, e.message()));
         return (
             StatusCode::MISDIRECTED_REQUEST,
             axum::Json(ApiError { code: e.code().into(), message: e.message().to_string() }),
         )
             .into_response();
     }
-    match state.auth.authorize(peer.ip()).await {
+    match state.auth().authorize(peer.ip()).await {
         Ok(id) => {
             tracing::info!(peer = %peer_ip, who = id.label(), method = %method, path = %path, "request");
             req.extensions_mut().insert(id);
@@ -235,7 +242,7 @@ pub async fn middleware(
             tracing::warn!(peer = %peer_ip, error = %e, "rejected");
             let resp = error_response(&e);
             let entry = super::audit::Entry::new(&peer_ip, None, &method, &path);
-            state.audit.record(match e {
+            state.record(match e {
                 RdcError::Unauthorized(_) | RdcError::Forbidden(_) => entry.denied(resp.status().as_u16(), e.message()),
                 _ => entry.error(resp.status().as_u16(), e.message()),
             });

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,8 +1,9 @@
 //! The daemon: axum on the Tailscale IP, every request identified via whois.
 
 pub mod audit;
-mod auth;
+pub mod auth;
 mod routes;
+pub mod stream;
 #[cfg(test)]
 mod tests;
 
@@ -20,6 +21,64 @@ pub struct AppState {
     pub desktop: Arc<dyn Desktop>,
     pub auth: Arc<auth::Auth>,
     pub audit: Arc<audit::Audit>,
+}
+
+impl auth::Gate for AppState {
+    fn auth(&self) -> &auth::Auth {
+        &self.auth
+    }
+    fn record(&self, e: audit::Entry) {
+        self.audit.record(e);
+    }
+}
+
+/// Where a listener goes and which `Host` names it answers to. Shared by `serve` and the audit
+/// viewer so both apply the same rules: Tailscale addresses only, loopback only for testing.
+pub struct Listen {
+    pub addr: SocketAddr,
+    pub hosts: Vec<String>,
+    /// This node's short name, for stamping into audit entries.
+    pub node: String,
+}
+
+pub async fn plan_listen(
+    ts: &Tailscale,
+    bind: Option<IpAddr>,
+    port: u16,
+    dev_loopback: bool,
+    extra_hosts: Vec<String>,
+) -> Result<Listen> {
+    let bind_ip = match bind {
+        Some(ip) => ip,
+        None if dev_loopback => IpAddr::from([127, 0, 0, 1]),
+        None => {
+            let ips = ts.self_ips().await.context("tailscaled unreachable; pass --bind to choose an address")?;
+            *ips.first().context("this node has no Tailscale IP; is tailscaled up?")?
+        }
+    };
+    if dev_loopback && !bind_ip.is_loopback() {
+        anyhow::bail!("--dev-loopback only allows a loopback bind address, not {bind_ip}");
+    }
+    if !dev_loopback && !is_tailscale_ip(bind_ip) {
+        anyhow::bail!(
+            "{bind_ip} is not a Tailscale address; refusing to listen on it (use --dev-loopback for 127.0.0.1)"
+        );
+    }
+    // Names a legitimate client would put in the URL. Anything else in the Host header means the
+    // request was not addressed to us (e.g. a browser lured by DNS rebinding) and is refused.
+    let mut hosts: Vec<String> = vec![bind_ip.to_string()];
+    if let Ok(ips) = ts.self_ips().await {
+        hosts.extend(ips.iter().map(|ip| ip.to_string()));
+    }
+    let names = ts.self_names().await;
+    let node = names.last().cloned().unwrap_or_else(|| bind_ip.to_string());
+    hosts.extend(names);
+    hosts.extend(extra_hosts);
+    if dev_loopback {
+        hosts.extend(["localhost".to_string(), "127.0.0.1".to_string(), "::1".to_string()]);
+    }
+    tracing::debug!(?hosts, "accepted Host names");
+    Ok(Listen { addr: SocketAddr::new(bind_ip, port), hosts, node })
 }
 
 pub struct ServeOpts {
@@ -44,52 +103,34 @@ pub async fn serve(desktop: Arc<dyn Desktop>, ts: Tailscale, opts: ServeOpts) ->
             );
         }
     }
-    let bind_ip = match opts.bind {
-        Some(ip) => ip,
-        None if opts.dev_loopback => IpAddr::from([127, 0, 0, 1]),
-        None => {
-            let ips = ts.self_ips().await.context("tailscaled unreachable; pass --bind to choose an address")?;
-            *ips.first().context("this node has no Tailscale IP; is tailscaled up?")?
-        }
-    };
-    if opts.dev_loopback && !bind_ip.is_loopback() {
-        anyhow::bail!("--dev-loopback only allows a loopback bind address, not {bind_ip}");
-    }
-    if !opts.dev_loopback && !is_tailscale_ip(bind_ip) {
-        anyhow::bail!(
-            "{bind_ip} is not a Tailscale address; refusing to expose the desktop on it (use --dev-loopback for 127.0.0.1)"
-        );
-    }
+    let listen = plan_listen(&ts, opts.bind, opts.port, opts.dev_loopback, opts.hosts).await?;
     if opts.grants.is_empty() && !opts.dev_loopback {
         anyhow::bail!("allowlist is empty: set [serve].allow in config or pass --allow; nobody could connect");
     }
     for g in &opts.grants {
         tracing::info!("allow {}", g.describe());
     }
-    let audit = audit::Audit::open(&opts.audit).context("opening the audit log")?;
+    let mut audit = audit::Audit::open(&opts.audit, &listen.node).context("opening the audit log")?;
     match audit.path() {
         Some(p) => tracing::info!("audit log: {}", p.display()),
         None => tracing::warn!("audit log disabled by config"),
     }
-    let addr = SocketAddr::new(bind_ip, opts.port);
-    // Names a legitimate client would put in the URL. Anything else in the Host header means the
-    // request was not addressed to us (e.g. a browser lured by DNS rebinding) and is refused.
-    let mut hosts: Vec<String> = vec![bind_ip.to_string()];
-    if let Ok(ips) = ts.self_ips().await {
-        hosts.extend(ips.iter().map(|ip| ip.to_string()));
+    if let Some(url) = &opts.audit.stream {
+        audit.stream_to(url, opts.audit.stream_token.as_deref()).context("audit stream")?;
+        tracing::info!("audit stream: {url}");
     }
-    hosts.extend(ts.self_names().await);
-    hosts.extend(opts.hosts);
-    if opts.dev_loopback {
-        hosts.extend(["localhost".to_string(), "127.0.0.1".to_string(), "::1".to_string()]);
-    }
-    tracing::debug!(?hosts, "accepted Host names");
-    let auth =
-        auth::Auth::new(Arc::new(ts), Allowlist::new(opts.grants), auth::HostAllow::new(hosts), opts.dev_loopback);
+    let addr = listen.addr;
+    let auth = auth::Auth::new(
+        Arc::new(ts),
+        Allowlist::new(opts.grants),
+        auth::HostAllow::new(listen.hosts),
+        opts.dev_loopback,
+    );
     if opts.dev_loopback {
         tracing::warn!("--dev-loopback: requests from 127.0.0.1 are NOT authenticated");
     }
-    let state = AppState { desktop, auth: Arc::new(auth), audit: Arc::new(audit) };
+    let audit = Arc::new(audit);
+    let state = AppState { desktop, auth: Arc::new(auth), audit: audit.clone() };
     let app = routes::router(state);
     let listener = tokio::net::TcpListener::bind(addr).await.with_context(|| format!("bind {addr}"))?;
     tracing::info!("rdc serving on http://{addr}");
@@ -99,6 +140,7 @@ pub async fn serve(desktop: Arc<dyn Desktop>, ts: Tailscale, opts: ServeOpts) ->
             tracing::info!("shutting down");
         })
         .await?;
+    audit.shutdown().await;
     Ok(())
 }
 

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -57,7 +57,7 @@ pub fn router(state: AppState) -> Router {
         .route("/v1/whoami", get(whoami_h))
         .route("/health", get(health_h))
         .fallback(not_found_h)
-        .layer(middleware::from_fn_with_state(state.clone(), auth::middleware))
+        .layer(middleware::from_fn_with_state(state.clone(), auth::middleware::<AppState>))
         .with_state(state)
 }
 

--- a/src/server/stream.rs
+++ b/src/server/stream.rs
@@ -1,0 +1,229 @@
+//! Forward audit entries, as JSON lines, to an HTTP endpoint.
+//!
+//! Lines are batched (up to `MAX_BATCH` or `FLUSH_AFTER`, whichever comes first) into one
+//! `POST` with `Content-Type: application/x-ndjson`. A failed post is retried with backoff
+//! while new lines queue behind it; when the queue is full, new lines are dropped and counted.
+//! The local file stays the record of truth. This is telemetry, not the audit log.
+
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+const QUEUE: usize = 4096;
+const MAX_BATCH: usize = 200;
+const FLUSH_AFTER: Duration = Duration::from_millis(500);
+const MAX_BACKOFF: Duration = Duration::from_secs(30);
+
+pub struct Streamer {
+    tx: Mutex<Option<mpsc::Sender<String>>>,
+    task: Mutex<Option<JoinHandle<()>>>,
+    dropped: AtomicU64,
+}
+
+impl Streamer {
+    pub fn spawn(url: &str, token: Option<&str>) -> anyhow::Result<Self> {
+        let url: reqwest::Url = url.parse().map_err(|e| anyhow::anyhow!("audit stream url {url:?}: {e}"))?;
+        if !matches!(url.scheme(), "http" | "https") {
+            anyhow::bail!("audit stream url must be http or https, got {url}");
+        }
+        let client = reqwest::Client::builder()
+            .user_agent(concat!("rdc/", env!("CARGO_PKG_VERSION")))
+            .timeout(Duration::from_secs(10))
+            .build()?;
+        let (tx, rx) = mpsc::channel(QUEUE);
+        let token = token.map(str::to_owned);
+        let task = tokio::spawn(pump(client, url, token, rx));
+        Ok(Self { tx: Mutex::new(Some(tx)), task: Mutex::new(Some(task)), dropped: AtomicU64::new(0) })
+    }
+
+    /// Queue one JSON line. Never blocks the request path.
+    pub fn push(&self, line: String) {
+        let Ok(tx) = self.tx.lock() else { return };
+        let Some(tx) = tx.as_ref() else { return };
+        if tx.try_send(line).is_err() {
+            let n = self.dropped.fetch_add(1, Ordering::Relaxed) + 1;
+            if n == 1 || n.is_multiple_of(1000) {
+                tracing::warn!("audit stream: endpoint not keeping up, {n} entries dropped so far (file is intact)");
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub fn dropped(&self) -> u64 {
+        self.dropped.load(Ordering::Relaxed)
+    }
+
+    /// Close the queue and give the pump a moment to post what it still holds.
+    pub async fn shutdown(&self) {
+        let tx = self.tx.lock().ok().and_then(|mut t| t.take());
+        drop(tx);
+        let task = self.task.lock().ok().and_then(|mut t| t.take());
+        if let Some(task) = task {
+            let _ = tokio::time::timeout(Duration::from_secs(3), task).await;
+        }
+    }
+}
+
+async fn pump(client: reqwest::Client, url: reqwest::Url, token: Option<String>, mut rx: mpsc::Receiver<String>) {
+    let mut pending: Vec<String> = Vec::new();
+    let mut closed = false;
+    while !closed {
+        // Wait for the first line, then gather a batch for a short while.
+        match rx.recv().await {
+            Some(l) => pending.push(l),
+            None => break,
+        }
+        let deadline = Instant::now() + FLUSH_AFTER;
+        while pending.len() < MAX_BATCH {
+            match tokio::time::timeout_at(deadline.into(), rx.recv()).await {
+                Ok(Some(l)) => pending.push(l),
+                Ok(None) => {
+                    closed = true;
+                    break;
+                }
+                Err(_) => break,
+            }
+        }
+        let mut backoff = Duration::from_secs(1);
+        loop {
+            match post(&client, &url, token.as_deref(), &pending).await {
+                Ok(()) => {
+                    pending.clear();
+                    break;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "audit stream: {e}; retrying in {}s ({} lines held)",
+                        backoff.as_secs(),
+                        pending.len()
+                    );
+                    if closed {
+                        // Shutting down: one retry is all the grace we give.
+                        return;
+                    }
+                    tokio::time::sleep(backoff).await;
+                    backoff = (backoff * 2).min(MAX_BACKOFF);
+                }
+            }
+        }
+    }
+    if !pending.is_empty() {
+        let _ = post(&client, &url, token.as_deref(), &pending).await;
+    }
+}
+
+async fn post(
+    client: &reqwest::Client,
+    url: &reqwest::Url,
+    token: Option<&str>,
+    lines: &[String],
+) -> anyhow::Result<()> {
+    let mut body = String::with_capacity(lines.iter().map(|l| l.len() + 1).sum());
+    for l in lines {
+        body.push_str(l);
+        body.push('\n');
+    }
+    let mut req = client.post(url.clone()).header(reqwest::header::CONTENT_TYPE, "application/x-ndjson").body(body);
+    if let Some(t) = token {
+        req = req.bearer_auth(t);
+    }
+    let resp = req.send().await.map_err(|e| anyhow::anyhow!("post to {}: {e}", redact(url)))?;
+    if !resp.status().is_success() {
+        anyhow::bail!("{} answered {}", redact(url), resp.status());
+    }
+    Ok(())
+}
+
+/// The URL without any userinfo or query, for log lines.
+fn redact(u: &reqwest::Url) -> String {
+    let mut u = u.clone();
+    let _ = u.set_username("");
+    let _ = u.set_password(None);
+    u.set_query(None);
+    u.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{Router, body::Bytes, extract::State, http::HeaderMap, routing::post};
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
+
+    #[derive(Default)]
+    struct Received {
+        bodies: Mutex<Vec<(HeaderMap, String)>>,
+        fail_first: AtomicUsize,
+    }
+
+    async fn sink(State(r): State<Arc<Received>>, headers: HeaderMap, body: Bytes) -> axum::http::StatusCode {
+        if r.fail_first.load(Ordering::Relaxed) > 0 {
+            r.fail_first.fetch_sub(1, Ordering::Relaxed);
+            return axum::http::StatusCode::INTERNAL_SERVER_ERROR;
+        }
+        r.bodies.lock().unwrap().push((headers, String::from_utf8_lossy(&body).into_owned()));
+        axum::http::StatusCode::ACCEPTED
+    }
+
+    async fn endpoint(fail_first: usize) -> (String, Arc<Received>) {
+        let r = Arc::new(Received { fail_first: AtomicUsize::new(fail_first), ..Default::default() });
+        let app = Router::new().route("/ingest", post(sink)).with_state(r.clone());
+        let l = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}/ingest", l.local_addr().unwrap());
+        tokio::spawn(async move { axum::serve(l, app).await.unwrap() });
+        (url, r)
+    }
+
+    #[tokio::test]
+    async fn batches_lines_as_ndjson_with_token() {
+        let (url, r) = endpoint(0).await;
+        let s = Streamer::spawn(&url, Some("s3cret")).unwrap();
+        for i in 0..5 {
+            s.push(format!(r#"{{"n":{i}}}"#));
+        }
+        s.shutdown().await;
+        let bodies = r.bodies.lock().unwrap();
+        assert_eq!(bodies.len(), 1, "five quick lines make one batch");
+        let (h, body) = &bodies[0];
+        assert_eq!(h.get("content-type").unwrap(), "application/x-ndjson");
+        assert_eq!(h.get("authorization").unwrap(), "Bearer s3cret");
+        assert!(h.get("user-agent").unwrap().to_str().unwrap().starts_with("rdc/"));
+        assert_eq!(body.lines().count(), 5);
+        assert!(body.ends_with('\n'));
+        assert_eq!(s.dropped(), 0);
+    }
+
+    #[tokio::test]
+    async fn retries_a_failed_batch_without_losing_or_duplicating() {
+        let (url, r) = endpoint(1).await;
+        let s = Streamer::spawn(&url, None).unwrap();
+        s.push(r#"{"n":1}"#.into());
+        // First post fails, the pump backs off 1 s and posts again.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while r.bodies.lock().unwrap().is_empty() && Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        s.shutdown().await;
+        let bodies = r.bodies.lock().unwrap();
+        assert_eq!(bodies.len(), 1, "delivered exactly once after the retry");
+        assert_eq!(bodies[0].1, "{\"n\":1}\n");
+        assert!(bodies[0].0.get("authorization").is_none());
+    }
+
+    #[test]
+    fn rejects_non_http_urls() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            assert!(Streamer::spawn("file:///tmp/x", None).is_err());
+            assert!(Streamer::spawn("not a url", None).is_err());
+        });
+    }
+
+    #[test]
+    fn redact_strips_secrets() {
+        let u: reqwest::Url = "https://user:pw@collector.example/ingest?token=abc".parse().unwrap();
+        assert_eq!(redact(&u), "https://collector.example/ingest");
+    }
+}

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -114,7 +114,8 @@ fn harness(name: &str) -> Harness {
     let _ = std::fs::remove_dir_all(&dir);
     let audit_path = dir.join("audit.jsonl");
     let audit =
-        Audit::open(&AuditConfig { enabled: true, path: Some(audit_path.clone()), max_size_mb: 1, keep: 1 }).unwrap();
+        Audit::open(&AuditConfig { enabled: true, path: Some(audit_path.clone()), ..Default::default() }, "studio-mac")
+            .unwrap();
     let desktop = Arc::new(FakeDesktop::default());
     let state = AppState { desktop: desktop.clone(), auth: Arc::new(auth), audit: Arc::new(audit) };
     Harness { app: routes::router(state), desktop, audit_path }
@@ -258,6 +259,7 @@ async fn everything_authorized_is_audited() {
     assert_eq!((lines[3].status, lines[3].action.as_deref()), (400, Some("act (unparsed)")));
     assert_eq!(lines[4].status, 400);
     assert_eq!(lines[5].action.as_deref(), Some("input.type 15 chars"), "typed text is never logged");
+    assert!(lines.iter().all(|e| e.host == "studio-mac"), "every entry names the machine");
     let raw = std::fs::read_to_string(&h.audit_path).unwrap();
     assert!(!raw.contains("secret password"));
 }

--- a/src/viewer/follow.rs
+++ b/src/viewer/follow.rs
@@ -1,0 +1,63 @@
+//! Follow a local audit file: seed from its tail, then poll for appended lines. Handles the
+//! file being rotated (size shrinks) or not existing yet.
+
+use super::Log;
+use crate::server::audit::{Entry, tail};
+use std::io::{Read, Seek, SeekFrom};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+const POLL: Duration = Duration::from_millis(500);
+const SEED: usize = 200;
+
+pub async fn follow(path: PathBuf, log: Arc<Log>) {
+    let mut pos: u64 = 0;
+    let mut seeded = false;
+    let mut partial = String::new();
+    loop {
+        let len = match tokio::fs::metadata(&path).await {
+            Ok(m) => m.len(),
+            Err(_) => {
+                tokio::time::sleep(POLL).await;
+                continue;
+            }
+        };
+        if !seeded {
+            if let Ok(entries) = tail(&path, SEED) {
+                for e in entries {
+                    log.push(e);
+                }
+            }
+            pos = len;
+            seeded = true;
+        }
+        if len < pos {
+            // Rotated or truncated: start over from the top of the new file.
+            pos = 0;
+            partial.clear();
+        }
+        if len > pos {
+            let p = path.clone();
+            let read = tokio::task::spawn_blocking(move || -> std::io::Result<String> {
+                let mut f = std::fs::File::open(&p)?;
+                f.seek(SeekFrom::Start(pos))?;
+                let mut buf = String::new();
+                f.take(len - pos).read_to_string(&mut buf)?;
+                Ok(buf)
+            })
+            .await;
+            if let Ok(Ok(chunk)) = read {
+                pos = len;
+                partial.push_str(&chunk);
+                while let Some(nl) = partial.find('\n') {
+                    let line: String = partial.drain(..=nl).collect();
+                    if let Ok(e) = serde_json::from_str::<Entry>(line.trim()) {
+                        log.push(e);
+                    }
+                }
+            }
+        }
+        tokio::time::sleep(POLL).await;
+    }
+}

--- a/src/viewer/index.html
+++ b/src/viewer/index.html
@@ -1,0 +1,196 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>rdc audit</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    --bg: #fbfaf7; --fg: #1d1f24; --muted: #6b6f7a; --line: #e2e0da; --row: #f2f0eb;
+    --ok: #2f6f4e; --denied: #b3261e; --denied-bg: #fbe9e7; --error: #8a5a00; --error-bg: #fff3d6;
+    --accent: #2b5ea7; --mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #15171b; --fg: #e6e4de; --muted: #9a9ea8; --line: #2c2f36; --row: #1c1f25;
+      --ok: #7fc99f; --denied: #ff8a80; --denied-bg: #3a1f1d; --error: #ffcf70; --error-bg: #3a3016;
+      --accent: #8ab4f8;
+    }
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--bg); color: var(--fg); font: 14px/1.45 system-ui, sans-serif; }
+  header { display: flex; flex-wrap: wrap; gap: 10px 16px; align-items: center; padding: 10px 16px;
+           border-bottom: 1px solid var(--line); position: sticky; top: 0; background: var(--bg); z-index: 1; }
+  header h1 { font-size: 15px; margin: 0 8px 0 0; font-weight: 600; letter-spacing: .02em; }
+  header label { display: inline-flex; gap: 6px; align-items: center; color: var(--muted); }
+  input, select, button { font: inherit; color: var(--fg); background: var(--row); border: 1px solid var(--line);
+                          border-radius: 6px; padding: 4px 8px; }
+  input[type=search] { min-width: 18em; }
+  button { cursor: pointer; }
+  .status { margin-left: auto; display: inline-flex; gap: 8px; align-items: center; color: var(--muted); font-variant-numeric: tabular-nums; }
+  .dot { width: 9px; height: 9px; border-radius: 50%; background: var(--muted); }
+  .dot.live { background: var(--ok); }
+  .dot.paused { background: var(--error); }
+  main { overflow-x: auto; }
+  table { width: 100%; border-collapse: collapse; font-variant-numeric: tabular-nums; }
+  th, td { text-align: left; padding: 5px 10px; border-bottom: 1px solid var(--line); vertical-align: top; white-space: nowrap; }
+  th { color: var(--muted); font-weight: 500; font-size: 12px; text-transform: uppercase; letter-spacing: .05em; }
+  td.what, td.detail { font-family: var(--mono); font-size: 12.5px; white-space: pre-wrap; word-break: break-word; }
+  td.detail { color: var(--muted); max-width: 40em; }
+  tr.denied td { background: var(--denied-bg); }
+  tr.denied td.outcome { color: var(--denied); font-weight: 600; }
+  tr.error td { background: var(--error-bg); }
+  tr.error td.outcome { color: var(--error); font-weight: 600; }
+  tr.ok td.outcome { color: var(--ok); }
+  td.ms { color: var(--muted); text-align: right; }
+  .empty { padding: 40px 16px; color: var(--muted); text-align: center; }
+  .via { color: var(--muted); font-size: 12px; }
+  footer { padding: 10px 16px; color: var(--muted); font-size: 12px; border-top: 1px solid var(--line); }
+  code { font-family: var(--mono); }
+</style>
+</head>
+<body>
+<header>
+  <h1>rdc audit</h1>
+  <input id="q" type="search" placeholder="filter: who, host, action, detail" autocomplete="off">
+  <label>outcome
+    <select id="outcome">
+      <option value="">all</option>
+      <option value="ok">ok</option>
+      <option value="denied">denied</option>
+      <option value="error">error</option>
+    </select>
+  </label>
+  <label>host <select id="host"><option value="">all</option></select></label>
+  <label><input id="pause" type="checkbox"> pause</label>
+  <button id="clear" type="button">clear</button>
+  <span class="status"><span id="dot" class="dot"></span><span id="count">0</span> shown · <span id="total">0</span> total</span>
+</header>
+<main>
+  <table>
+    <thead><tr>
+      <th>time</th><th>host</th><th>who</th><th>what</th><th>outcome</th><th>code</th><th>ms</th><th>detail</th>
+    </tr></thead>
+    <tbody id="rows"></tbody>
+  </table>
+  <div id="empty" class="empty">Waiting for entries. Point a daemon here with
+    <code>[serve.audit] stream = "http://this-host:port/v1/ingest"</code>.</div>
+</main>
+<footer>Newest first. Entries are shown exactly as recorded; typed text never appears in the log.</footer>
+<script>
+(function () {
+  'use strict';
+  var MAX_ROWS = 5000;
+  var entries = [];           // newest first
+  var hosts = {};
+  var pendingWhilePaused = [];
+  var $ = function (id) { return document.getElementById(id); };
+  var rows = $('rows'), q = $('q'), outcomeSel = $('outcome'), hostSel = $('host'), pause = $('pause');
+  var dot = $('dot'), count = $('count'), total = $('total'), empty = $('empty');
+
+  function who(e) { return e.login || e.node || e.peer || ''; }
+  function what(e) { return e.action || (e.method + ' ' + e.path); }
+  function matches(e) {
+    if (outcomeSel.value && e.outcome !== outcomeSel.value) return false;
+    if (hostSel.value && e.host !== hostSel.value) return false;
+    var needle = q.value.trim().toLowerCase();
+    if (!needle) return true;
+    var hay = [e.ts, e.host, who(e), (e.tags || []).join(' '), what(e), e.outcome, String(e.status), e.detail || '', e.via || ''].join(' ').toLowerCase();
+    return hay.indexOf(needle) !== -1;
+  }
+  function cell(cls, text, title) {
+    var td = document.createElement('td');
+    if (cls) td.className = cls;
+    td.textContent = text == null ? '' : String(text);
+    if (title) td.title = title;
+    return td;
+  }
+  function row(e) {
+    var tr = document.createElement('tr');
+    tr.className = e.outcome || '';
+    tr.appendChild(cell('ts', (e.ts || '').replace('T', ' ').replace('Z', '')));
+    var host = cell('host', e.host || '');
+    if (e.via && e.via !== e.host) {
+      var via = document.createElement('div'); via.className = 'via'; via.textContent = 'via ' + e.via; host.appendChild(via);
+    }
+    tr.appendChild(host);
+    tr.appendChild(cell('who', who(e), (e.tags || []).join(' ') + (e.peer ? '\n' + e.peer : '')));
+    tr.appendChild(cell('what', what(e)));
+    tr.appendChild(cell('outcome', e.outcome));
+    tr.appendChild(cell('code', e.status));
+    tr.appendChild(cell('ms', e.ms == null ? '' : e.ms));
+    tr.appendChild(cell('detail', e.detail || ''));
+    return tr;
+  }
+  function noteHost(e) {
+    if (!e.host || hosts[e.host]) return;
+    hosts[e.host] = true;
+    var o = document.createElement('option'); o.value = e.host; o.textContent = e.host; hostSel.appendChild(o);
+  }
+  function render() {
+    var frag = document.createDocumentFragment(), shown = 0;
+    for (var i = 0; i < entries.length; i++) {
+      if (matches(entries[i])) { frag.appendChild(row(entries[i])); shown++; }
+    }
+    rows.textContent = '';
+    rows.appendChild(frag);
+    count.textContent = shown;
+    total.textContent = entries.length;
+    empty.hidden = entries.length > 0;
+  }
+  function add(e, live) {
+    noteHost(e);
+    entries.unshift(e);
+    if (entries.length > MAX_ROWS) entries.length = MAX_ROWS;
+    total.textContent = entries.length;
+    empty.hidden = true;
+    if (!live) return;
+    if (matches(e)) {
+      rows.insertBefore(row(e), rows.firstChild);
+      while (rows.children.length > MAX_ROWS) rows.removeChild(rows.lastChild);
+      count.textContent = Number(count.textContent) + 1;
+    }
+  }
+  function onEntry(ev) {
+    var e;
+    try { e = JSON.parse(ev.data); } catch (err) { return; }
+    if (pause.checked) { pendingWhilePaused.push(e); return; }
+    add(e, true);
+  }
+  function connect() {
+    var es = new EventSource('/v1/events');
+    es.addEventListener('entry', onEntry);
+    es.addEventListener('lagged', function () { load(); });
+    es.onopen = function () { dot.className = 'dot live'; dot.title = 'live'; };
+    es.onerror = function () { dot.className = 'dot'; dot.title = 'reconnecting'; };
+  }
+  function load() {
+    fetch('/v1/recent?n=' + MAX_ROWS, { credentials: 'same-origin' })
+      .then(function (r) { return r.ok ? r.json() : []; })
+      .then(function (list) {
+        entries = [];
+        hosts = {};
+        hostSel.length = 1;
+        for (var i = 0; i < list.length; i++) add(list[i], false);
+        render();
+      })
+      .catch(function () {});
+  }
+  q.addEventListener('input', render);
+  outcomeSel.addEventListener('change', render);
+  hostSel.addEventListener('change', render);
+  pause.addEventListener('change', function () {
+    dot.className = pause.checked ? 'dot paused' : 'dot live';
+    if (!pause.checked) {
+      var held = pendingWhilePaused; pendingWhilePaused = [];
+      for (var i = 0; i < held.length; i++) add(held[i], true);
+    }
+  });
+  $('clear').addEventListener('click', function () { entries = []; render(); });
+  load();
+  connect();
+})();
+</script>
+</body>
+</html>

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -1,0 +1,267 @@
+//! `rdc audit-view`: a small web server that collects audit entries from `rdc serve`
+//! instances (and local audit files) and shows them live in a browser.
+//!
+//! Same gate as the daemon: it listens on the Tailscale IP only, checks the `Host` header, and
+//! identifies every caller through tailscaled `whois` against an allowlist. Daemons post JSON
+//! lines to `/v1/ingest`; browsers load `/` and follow `/v1/events` (server-sent events).
+
+mod follow;
+#[cfg(test)]
+mod tests;
+
+use crate::config::{AuditConfig, ResolvedGrant};
+use crate::proto::{Identity, RdcError};
+use crate::server::audit::{Audit, Entry, sanitize};
+use crate::server::auth::{self, Allowlist, Auth, Gate, HostAllow};
+use crate::server::plan_listen;
+use crate::tailscale::Tailscale;
+use anyhow::{Context, Result};
+use axum::{
+    Json, Router,
+    body::Bytes,
+    extract::{DefaultBodyLimit, Extension, Query, State},
+    http::{HeaderValue, StatusCode, header},
+    middleware,
+    response::{
+        Html, IntoResponse, Response,
+        sse::{Event, KeepAlive, Sse},
+    },
+    routing::{get, post},
+};
+use futures::Stream;
+use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+use std::convert::Infallible;
+use std::net::IpAddr;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use tokio::sync::broadcast;
+
+/// Entries kept in memory for the page's initial load.
+const RING: usize = 5000;
+/// Largest accepted `/v1/ingest` body.
+const MAX_INGEST: usize = 8 << 20;
+/// Longest single line accepted from a sender.
+const MAX_LINE: usize = 8192;
+
+pub struct ViewOpts {
+    pub bind: Option<IpAddr>,
+    pub port: u16,
+    pub grants: Vec<ResolvedGrant>,
+    pub hosts: Vec<String>,
+    pub dev_loopback: bool,
+    /// Where received entries are kept, or `None` for memory only.
+    pub store: Option<AuditConfig>,
+    pub follow: Vec<PathBuf>,
+}
+
+/// Everything the viewer has seen: a bounded ring for newcomers, a broadcast for live pages,
+/// and the store file.
+pub struct Log {
+    ring: Mutex<VecDeque<Entry>>,
+    tx: broadcast::Sender<Arc<str>>,
+    store: Audit,
+    node: String,
+}
+
+impl Log {
+    pub fn new(store: Audit, node: &str) -> Self {
+        let (tx, _) = broadcast::channel(1024);
+        Self { ring: Mutex::new(VecDeque::with_capacity(RING)), tx, store, node: node.to_string() }
+    }
+
+    pub fn push(&self, e: Entry) {
+        let mut e = e.sanitized();
+        if e.host.is_empty() {
+            e.host = self.node.clone();
+        }
+        self.store.record(e.clone());
+        let line = match serde_json::to_string(&e) {
+            Ok(l) => l,
+            Err(_) => return,
+        };
+        if let Ok(mut r) = self.ring.lock() {
+            if r.len() == RING {
+                r.pop_front();
+            }
+            r.push_back(e);
+        }
+        let _ = self.tx.send(line.into());
+    }
+
+    pub fn recent(&self, n: usize, host: Option<&str>) -> Vec<Entry> {
+        let Ok(r) = self.ring.lock() else { return vec![] };
+        r.iter()
+            .rev()
+            .filter(|e| host.is_none_or(|h| e.host == h))
+            .take(n)
+            .cloned()
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect()
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<Arc<str>> {
+        self.tx.subscribe()
+    }
+}
+
+#[derive(Clone)]
+pub struct ViewerState {
+    pub auth: Arc<Auth>,
+    pub log: Arc<Log>,
+}
+
+impl Gate for ViewerState {
+    fn auth(&self) -> &Auth {
+        &self.auth
+    }
+    fn record(&self, e: Entry) {
+        self.log.push(e);
+    }
+}
+
+pub async fn run(ts: Tailscale, opts: ViewOpts) -> Result<()> {
+    let listen = plan_listen(&ts, opts.bind, opts.port, opts.dev_loopback, opts.hosts).await?;
+    if opts.grants.is_empty() && !opts.dev_loopback {
+        anyhow::bail!(
+            "allowlist is empty: set [audit_view].allow in config or pass --allow; nobody could send or view"
+        );
+    }
+    for g in &opts.grants {
+        tracing::info!("allow {}", g.who.join(", "));
+    }
+    let store = match &opts.store {
+        Some(cfg) => {
+            let a = Audit::open(cfg, &listen.node).context("opening the store file")?;
+            if let Some(p) = a.path() {
+                tracing::info!("storing received entries in {}", p.display());
+            }
+            a
+        }
+        None => {
+            tracing::info!("not storing entries (memory only)");
+            Audit::disabled()
+        }
+    };
+    let log = Arc::new(Log::new(store, &listen.node));
+    for path in opts.follow {
+        tracing::info!("following {}", path.display());
+        tokio::spawn(follow::follow(path, log.clone()));
+    }
+    let auth = Auth::new(Arc::new(ts), Allowlist::new(opts.grants), HostAllow::new(listen.hosts), opts.dev_loopback);
+    if opts.dev_loopback {
+        tracing::warn!("--dev-loopback: requests from 127.0.0.1 are NOT authenticated");
+    }
+    let state = ViewerState { auth: Arc::new(auth), log };
+    let app = router(state);
+    let listener = tokio::net::TcpListener::bind(listen.addr).await.with_context(|| format!("bind {}", listen.addr))?;
+    tracing::info!("audit viewer at http://{}/  (daemons stream to http://{}/v1/ingest)", listen.addr, listen.addr);
+    axum::serve(listener, app.into_make_service_with_connect_info::<std::net::SocketAddr>())
+        .with_graceful_shutdown(async {
+            let _ = tokio::signal::ctrl_c().await;
+            tracing::info!("shutting down");
+        })
+        .await?;
+    Ok(())
+}
+
+pub fn router(state: ViewerState) -> Router {
+    Router::new()
+        .route("/", get(index_h))
+        .route("/v1/ingest", post(ingest_h).layer(DefaultBodyLimit::max(MAX_INGEST)))
+        .route("/v1/recent", get(recent_h))
+        .route("/v1/events", get(events_h))
+        .route("/health", get(|| async { Json(serde_json::json!({"ok": true})) }))
+        .fallback(|| async { auth::error_response(&RdcError::NotFound("no such route".into())) })
+        .layer(middleware::from_fn_with_state(state.clone(), auth::middleware::<ViewerState>))
+        .with_state(state)
+}
+
+async fn index_h() -> Response {
+    let mut resp = Html(include_str!("index.html")).into_response();
+    let h = resp.headers_mut();
+    h.insert(
+        header::CONTENT_SECURITY_POLICY,
+        HeaderValue::from_static(
+            "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; connect-src 'self'; \
+             img-src data:; base-uri 'none'; form-action 'none'; frame-ancestors 'none'",
+        ),
+    );
+    h.insert(header::X_CONTENT_TYPE_OPTIONS, HeaderValue::from_static("nosniff"));
+    h.insert(header::REFERRER_POLICY, HeaderValue::from_static("no-referrer"));
+    h.insert(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
+    resp
+}
+
+#[derive(Serialize)]
+struct Ingested {
+    accepted: usize,
+    rejected: usize,
+}
+
+async fn ingest_h(State(s): State<ViewerState>, Extension(id): Extension<Identity>, body: Bytes) -> Response {
+    let text = match std::str::from_utf8(&body) {
+        Ok(t) => t,
+        Err(_) => {
+            s.log.push(Entry::new(&id.ip, Some(&id), "POST", "/v1/ingest").error(400, "body is not UTF-8"));
+            return auth::error_response(&RdcError::BadRequest("body is not UTF-8".into()));
+        }
+    };
+    let (mut accepted, mut rejected) = (0usize, 0usize);
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if line.len() > MAX_LINE {
+            rejected += 1;
+            continue;
+        }
+        match serde_json::from_str::<Entry>(line) {
+            Ok(mut e) => {
+                // Provenance is ours to assert, not the sender's.
+                e.via = Some(id.node.clone());
+                if e.host.is_empty() {
+                    e.host = id.node.clone();
+                }
+                s.log.push(e);
+                accepted += 1;
+            }
+            Err(_) => rejected += 1,
+        }
+    }
+    if rejected > 0 {
+        let why = format!("{rejected} of {} lines were not audit entries", accepted + rejected);
+        tracing::warn!(from = %id.node, "{why}");
+        s.log.push(Entry::new(&id.ip, Some(&id), "POST", "/v1/ingest").action("ingest").error(400, sanitize(&why)));
+        return (StatusCode::BAD_REQUEST, Json(Ingested { accepted, rejected })).into_response();
+    }
+    Json(Ingested { accepted, rejected }).into_response()
+}
+
+#[derive(Deserialize)]
+struct RecentQuery {
+    n: Option<usize>,
+    host: Option<String>,
+}
+
+async fn recent_h(State(s): State<ViewerState>, Query(q): Query<RecentQuery>) -> Json<Vec<Entry>> {
+    Json(s.log.recent(q.n.unwrap_or(500).min(RING), q.host.as_deref()))
+}
+
+async fn events_h(State(s): State<ViewerState>) -> Sse<impl Stream<Item = std::result::Result<Event, Infallible>>> {
+    let rx = s.log.subscribe();
+    let stream = futures::stream::unfold(rx, |mut rx| async move {
+        match rx.recv().await {
+            Ok(line) => Some((Ok(Event::default().event("entry").data(line.as_ref())), rx)),
+            // The page fell behind; tell it to reload the recent window rather than miss rows.
+            Err(broadcast::error::RecvError::Lagged(n)) => {
+                Some((Ok(Event::default().event("lagged").data(n.to_string())), rx))
+            }
+            Err(broadcast::error::RecvError::Closed) => None,
+        }
+    });
+    Sse::new(stream).keep_alive(KeepAlive::default())
+}

--- a/src/viewer/tests.rs
+++ b/src/viewer/tests.rs
@@ -1,0 +1,215 @@
+//! Viewer router tests: the real stack with a fake identity table.
+
+use super::{Log, ViewerState, router};
+use crate::config::{AuditConfig, ResolvedGrant};
+use crate::proto::{Identity, RdcError};
+use crate::server::audit::{Audit, Entry};
+use crate::server::auth::{Allowlist, Auth, HostAllow, Identify};
+use async_trait::async_trait;
+use axum::{
+    Router,
+    body::Body,
+    extract::ConnectInfo,
+    http::{Request, StatusCode},
+};
+use http_body_util::BodyExt;
+use std::collections::HashMap;
+use std::net::{IpAddr, SocketAddr};
+use std::path::PathBuf;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+struct Table(HashMap<IpAddr, Identity>);
+
+#[async_trait]
+impl Identify for Table {
+    async fn whois(&self, ip: IpAddr) -> Result<Identity, RdcError> {
+        self.0.get(&ip).cloned().ok_or_else(|| RdcError::Unauthorized(format!("{ip} unknown")))
+    }
+}
+
+const MAC: &str = "100.64.0.10"; // a daemon that is allowed to send
+const ADMIN: &str = "100.64.0.11"; // the person viewing
+const STRANGER: &str = "100.64.0.30";
+
+fn ident(login: Option<&str>, node: &str) -> Identity {
+    Identity { login: login.map(String::from), node: node.into(), tags: vec![], ip: String::new(), caps: vec![] }
+}
+
+struct H {
+    app: Router,
+    log: Arc<Log>,
+    store: PathBuf,
+}
+
+fn harness(name: &str) -> H {
+    let mut t = HashMap::new();
+    t.insert(MAC.parse().unwrap(), ident(Some("brian@example.com"), "studio-mac"));
+    t.insert(ADMIN.parse().unwrap(), ident(Some("brian@example.com"), "laptop"));
+    t.insert(STRANGER.parse().unwrap(), ident(Some("mallory@example.com"), "mallory-pc"));
+    let auth = Auth::new(
+        Arc::new(Table(t)),
+        Allowlist::new(vec![ResolvedGrant::full(vec!["brian@example.com".into()])]),
+        HostAllow::new(vec!["100.64.0.1".into()]),
+        false,
+    );
+    let dir = std::env::temp_dir().join(format!("rdc-viewer-test-{}-{name}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    let store = dir.join("audit-view.jsonl");
+    let audit = Audit::open(&AuditConfig { path: Some(store.clone()), ..Default::default() }, "laptop").unwrap();
+    let log = Arc::new(Log::new(audit, "laptop"));
+    let state = ViewerState { auth: Arc::new(auth), log: log.clone() };
+    H { app: router(state), log, store }
+}
+
+async fn call(h: &H, peer: &str, method: &str, path: &str, body: Option<&str>) -> (StatusCode, String) {
+    let mut req = Request::builder().method(method).uri(path).header("host", "100.64.0.1");
+    if body.is_some() {
+        req = req.header("content-type", "application/x-ndjson");
+    }
+    let mut req = req.body(Body::from(body.unwrap_or("").to_string())).unwrap();
+    req.extensions_mut().insert(ConnectInfo(SocketAddr::new(peer.parse().unwrap(), 5000)));
+    let resp = h.app.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    (status, String::from_utf8_lossy(&bytes).into_owned())
+}
+
+fn line(host: &str, action: &str) -> String {
+    let mut e = Entry::new("100.64.0.99", None, "POST", "/v1/act").action(action);
+    e.host = host.into();
+    serde_json::to_string(&e).unwrap()
+}
+
+#[tokio::test]
+async fn ingest_stamps_provenance_and_serves_recent() {
+    let h = harness("ingest");
+    let mut rx = h.log.subscribe();
+    let body = format!("{}\n{}\n\n", line("studio-mac", "input.click 1,1 Left x1"), line("", "screenshot all png"));
+    let (st, resp) = call(&h, MAC, "POST", "/v1/ingest", Some(&body)).await;
+    assert_eq!(st, StatusCode::OK, "{resp}");
+    assert_eq!(resp, r#"{"accepted":2,"rejected":0}"#);
+    let (st, recent) = call(&h, ADMIN, "GET", "/v1/recent?n=10", None).await;
+    assert_eq!(st, StatusCode::OK);
+    let got: Vec<Entry> = serde_json::from_str(&recent).unwrap();
+    assert_eq!(got.len(), 2);
+    assert_eq!(got[0].host, "studio-mac");
+    assert_eq!(got[0].via.as_deref(), Some("studio-mac"), "via is set by the viewer, not the sender");
+    assert_eq!(got[1].host, "studio-mac", "an entry without a host is attributed to its sender");
+    // live subscribers saw both lines
+    let first: Entry = serde_json::from_str(&rx.recv().await.unwrap()).unwrap();
+    assert_eq!(first.action.as_deref(), Some("input.click 1,1 Left x1"));
+    assert!(rx.try_recv().is_ok());
+    // and the store file has them
+    let stored = std::fs::read_to_string(&h.store).unwrap();
+    assert_eq!(stored.lines().count(), 2);
+    // filter by host
+    let (_, only) = call(&h, ADMIN, "GET", "/v1/recent?host=nowhere", None).await;
+    assert_eq!(only, "[]");
+}
+
+#[tokio::test]
+async fn a_sender_cannot_forge_its_own_provenance() {
+    let h = harness("forge");
+    let mut e = Entry::new("1.2.3.4", None, "GET", "/v1/state");
+    e.via = Some("laptop".into());
+    e.host = "the-admins-box\u{1b}[2J".into();
+    let body = serde_json::to_string(&e).unwrap();
+    let (st, _) = call(&h, MAC, "POST", "/v1/ingest", Some(&body)).await;
+    assert_eq!(st, StatusCode::OK);
+    let got = h.log.recent(10, None);
+    assert_eq!(got[0].via.as_deref(), Some("studio-mac"));
+    assert_eq!(got[0].host, "the-admins-box\u{fffd}[2J", "control characters are neutralised on arrival");
+}
+
+#[tokio::test]
+async fn garbage_lines_are_counted_and_recorded() {
+    let h = harness("garbage");
+    let body = format!("{}\nnot json\n{{\"ts\":1}}\n", line("studio-mac", "whoami"));
+    let (st, resp) = call(&h, MAC, "POST", "/v1/ingest", Some(&body)).await;
+    assert_eq!(st, StatusCode::BAD_REQUEST);
+    assert_eq!(resp, r#"{"accepted":1,"rejected":2}"#);
+    let got = h.log.recent(10, None);
+    assert_eq!(got.len(), 2, "the good line plus one entry about the bad ones");
+    let meta = got.last().unwrap();
+    assert_eq!((meta.outcome.as_str(), meta.status), ("error", 400));
+    assert_eq!(meta.host, "laptop", "the viewer's own entries carry the viewer's host");
+    assert_eq!(meta.node.as_deref(), Some("studio-mac"));
+    let (st, _) = call(&h, MAC, "POST", "/v1/ingest", Some("\u{ff}\u{fe}")).await;
+    assert_eq!(st, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn strangers_and_wrong_hosts_are_refused_and_logged() {
+    let h = harness("auth");
+    let (st, _) = call(&h, STRANGER, "POST", "/v1/ingest", Some(&line("x", "y"))).await;
+    assert_eq!(st, StatusCode::FORBIDDEN);
+    let (st, _) = call(&h, STRANGER, "GET", "/", None).await;
+    assert_eq!(st, StatusCode::FORBIDDEN);
+    let (st, _) = call(&h, "203.0.113.9", "GET", "/v1/recent", None).await;
+    assert_eq!(st, StatusCode::FORBIDDEN);
+    let mut req = Request::builder().uri("/").header("host", "evil.example").body(Body::empty()).unwrap();
+    req.extensions_mut().insert(ConnectInfo(SocketAddr::new(ADMIN.parse().unwrap(), 1)));
+    let resp = h.app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::MISDIRECTED_REQUEST);
+    let got = h.log.recent(10, None);
+    assert_eq!(got.len(), 4);
+    assert!(got.iter().all(|e| e.outcome == "denied" && e.host == "laptop"));
+    assert!(got[0].detail.as_deref().unwrap().contains("mallory-pc"), "{:?}", got[0].detail);
+    assert_eq!(got[3].status, 421);
+}
+
+#[tokio::test]
+async fn page_and_health_for_allowed_viewer() {
+    let h = harness("page");
+    let mut req = Request::builder().uri("/").header("host", "100.64.0.1").body(Body::empty()).unwrap();
+    req.extensions_mut().insert(ConnectInfo(SocketAddr::new(ADMIN.parse().unwrap(), 1)));
+    let resp = h.app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(resp.headers().get("content-type").unwrap().to_str().unwrap().starts_with("text/html"));
+    let csp = resp.headers().get("content-security-policy").unwrap().to_str().unwrap();
+    assert!(csp.contains("default-src 'none'") && csp.contains("connect-src 'self'"));
+    let html = String::from_utf8_lossy(&resp.into_body().collect().await.unwrap().to_bytes()).into_owned();
+    assert!(html.contains("/v1/events") && html.contains("/v1/recent"));
+    assert!(!html.contains("innerHTML"), "the page never interprets log content as HTML");
+    let (st, body) = call(&h, ADMIN, "GET", "/health", None).await;
+    assert_eq!(st, StatusCode::OK);
+    assert_eq!(body, r#"{"ok":true}"#);
+    let (st, _) = call(&h, ADMIN, "GET", "/nope", None).await;
+    assert_eq!(st, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn follows_a_local_file_through_rotation() {
+    let h = harness("follow");
+    let dir = h.store.parent().unwrap().to_path_buf();
+    let path = dir.join("local-audit.jsonl");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(&path, format!("{}\n", line("", "seeded"))).unwrap();
+    let mut rx = h.log.subscribe();
+    tokio::spawn(super::follow::follow(path.clone(), h.log.clone()));
+    let seeded: Entry = serde_json::from_str(
+        &tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv()).await.unwrap().unwrap(),
+    )
+    .unwrap();
+    assert_eq!(seeded.action.as_deref(), Some("seeded"));
+    assert_eq!(seeded.host, "laptop", "local entries without a host get the viewer's");
+    {
+        use std::io::Write;
+        let mut f = std::fs::OpenOptions::new().append(true).open(&path).unwrap();
+        writeln!(f, "{}", line("", "appended")).unwrap();
+    }
+    let appended: Entry = serde_json::from_str(
+        &tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv()).await.unwrap().unwrap(),
+    )
+    .unwrap();
+    assert_eq!(appended.action.as_deref(), Some("appended"));
+    // rotate: a smaller new file is read from the start
+    std::fs::write(&path, format!("{}\n", line("", "after-rotate"))).unwrap();
+    let rotated: Entry = serde_json::from_str(
+        &tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv()).await.unwrap().unwrap(),
+    )
+    .unwrap();
+    assert_eq!(rotated.action.as_deref(), Some("after-rotate"));
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
## What
- `[serve.audit] stream = "http://…/v1/ingest"` or `rdc serve --audit-stream URL`: the daemon POSTs its audit entries, batched as `application/x-ndjson`, to any HTTP endpoint that takes newline-delimited JSON. Retry with backoff, bounded queue, local file untouched. Optional `stream_token` bearer header for third-party collectors.
- `rdc audit-view`: a live viewer. Same gate as the daemon (Tailscale bind, Host check, whois identity, allowlist). Receives streams from any number of daemons, follows local files with `--follow`, stores to a rotated file, and serves a page that updates over server-sent events with text, outcome and host filters.
- Audit entries gain `host` (daemon node name) and, on the viewer, `via` (the sending node, set by the viewer only). Old lines still parse.
- Docs: new "Audit log and live viewer" page, config and CLI reference, README line, CHANGELOG.

## Why
Brian wants to watch what agents do on all machines in one place, in real time, and to be able to ship the log to a standard collector.

## Tests
- Streamer: ndjson batching with token and user-agent; a failed batch is retried and delivered exactly once; non-http URLs refused; URL redaction.
- Viewer router: ingest stamps provenance and serves recent/live/store; a sender cannot forge `via` or smuggle control characters; garbage lines counted and recorded; strangers, non-Tailscale peers and wrong Host refused and logged; page CSP headers; following a local file through rotation.
- Existing router tests updated for `host`. `cargo test`: 44 passed.

## Ran on
Linux: `rdc audit-view --dev-loopback --no-store`, posted a batch with curl, checked `/v1/recent`, CSP headers, 421 on a wrong Host, and rendered the page in headless Chromium. Clippy clean on Linux, `x86_64-pc-windows-gnu` and `aarch64-apple-darwin`. Daemon-to-viewer streaming between real machines is still to be done on the release branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
