### PR TITLE
Audit host is the MagicDNS label; tidy screenshot action text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ builds the GitHub release body from the matching `## <version>` section.
   follows local files with `--follow`), stores them, and serves a page that updates as entries
   arrive, with text, outcome and host filters. Same gate as the daemon: Tailscale bind, Host
   check, `whois` identity, allowlist. Configured under `[audit_view]`.
-- Audit entries carry `host` (the daemon's node name); the viewer adds `via` (the sending
-  node) and never trusts the sender for it. Old lines without `host` still parse.
+- Audit entries carry `host` (the daemon's node name, the first label of its MagicDNS name);
+  the viewer adds `via` (the sending node) and never trusts the sender for it. Old lines without
+  `host` still parse.
 
 ### Changed
 - Release flow: pull requests target a `release/<version>` branch, which is tested on real

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -71,7 +71,7 @@ pub async fn plan_listen(
         hosts.extend(ips.iter().map(|ip| ip.to_string()));
     }
     let names = ts.self_names().await;
-    let node = names.last().cloned().unwrap_or_else(|| bind_ip.to_string());
+    let node = node_name(&names).unwrap_or_else(|| bind_ip.to_string());
     hosts.extend(names);
     hosts.extend(extra_hosts);
     if dev_loopback {
@@ -144,6 +144,15 @@ pub async fn serve(desktop: Arc<dyn Desktop>, ts: Tailscale, opts: ServeOpts) ->
     Ok(())
 }
 
+/// The short name to stamp into audit entries: the first label of the MagicDNS name
+/// (`studio-mac` from `studio-mac.example.ts.net`), which is what people type in `allow` and
+/// in the viewer's filters. Falls back to whatever name tailscaled gave us.
+fn node_name(names: &[String]) -> Option<String> {
+    let first = names.first()?;
+    let label = first.split('.').next().unwrap_or(first);
+    Some(if label.is_empty() { first.clone() } else { label.to_string() })
+}
+
 /// 100.64.0.0/10 (CGNAT range Tailscale uses) or fd7a:115c:a1e0::/48.
 pub fn is_tailscale_ip(ip: IpAddr) -> bool {
     match ip {
@@ -155,5 +164,18 @@ pub fn is_tailscale_ip(ip: IpAddr) -> bool {
             let s = v6.segments();
             s[0] == 0xfd7a && s[1] == 0x115c && s[2] == 0xa1e0
         }
+    }
+}
+
+#[cfg(test)]
+mod node_name_tests {
+    use super::node_name;
+
+    #[test]
+    fn prefers_the_magicdns_label_over_the_hostname() {
+        let names = vec!["brians-m4-mac-mini.example.ts.net".to_string(), "brian’s m4 mac mini".to_string()];
+        assert_eq!(node_name(&names).as_deref(), Some("brians-m4-mac-mini"));
+        assert_eq!(node_name(&["omen".to_string()]).as_deref(), Some("omen"));
+        assert_eq!(node_name(&[]), None);
     }
 }

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -116,7 +116,10 @@ async fn screenshot_h(
         }
     };
     let req = ScreenshotReq { display, format, max_long_edge: q.max };
-    let action = format!("screenshot {display} {} max={:?}", format.ext(), q.max);
+    let action = match q.max {
+        Some(m) => format!("screenshot {display} {} max={m}", format.ext()),
+        None => format!("screenshot {display} {}", format.ext()),
+    };
     match audited(&s, &id, "GET", "/v1/screenshot", Capability::View, Some(action), s.desktop.screenshot(req)).await {
         Ok(shot) => {
             let mut h = HeaderMap::new();

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -225,6 +225,8 @@ async fn screenshot_returns_geometry_headers() {
     assert_eq!(resp.headers().get("x-rdc-rect").unwrap(), "0,0,1440,960");
     assert_eq!(resp.headers().get("x-rdc-size").unwrap(), "720,480");
     assert_eq!(resp.headers().get("content-type").unwrap(), "image/jpeg");
+    let shots: Vec<_> = audit_lines(&h).into_iter().filter(|e| e.path == "/v1/screenshot").collect();
+    assert_eq!(shots[0].action.as_deref(), Some("screenshot primary jpg max=800"));
     let (st, body) = call(&h, ALICE, "100.64.0.1", "GET", "/v1/screenshot?display=zzz", None).await;
     assert_eq!(st, StatusCode::BAD_REQUEST, "{body}");
 }


### PR DESCRIPTION
## What
- `host` in audit entries is now the first label of the node's MagicDNS name (`brians-m4-mac-mini`), not the OS hostname (`brian’s m4 mac mini`).
- Screenshot audit actions read `max=800` instead of `max=Some(800)`.

## Tests
Unit test for the label selection; the screenshot router test now asserts the action text. `cargo test`: 45 passed.

## Ran on
Found during the live streaming test from the Mac mini to `rdc audit-view` on the laptop (release/0.4.0 build). Linux build, tests and clippy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
