### PR TITLE
Release 0.4.0: version bump and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ builds the GitHub release body from the matching `## <version>` section.
 
 ## Unreleased
 
+## 0.4.0 — 2026-09-11
+
 ### Added
 - **Audit streaming.** `[serve.audit] stream = "http://…/v1/ingest"` (or `rdc serve
   --audit-stream URL`) POSTs every audit entry, batched as `application/x-ndjson`, to an HTTP

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2234,7 +2234,7 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rdc"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdc"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 description = "Remote Desktop Control: let an AI agent see and drive another machine's desktop over Tailscale"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
Moves the Unreleased entries under 0.4.0 and bumps the crate version. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)